### PR TITLE
Add libomp to macOS requirements.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
 https://brew.sh/
 
 # Install dependencies
-brew install bazel cmake ninja nasm
+brew install bazel cmake ninja nasm libomp
 
 # Extra setup step for Apple Silicon users
 conda install grpcio


### PR DESCRIPTION
Fixed #38 