### PR TITLE
fix kkrt psi collision handing bug

### DIFF
--- a/libspu/psi/core/kkrt_psi.cc
+++ b/libspu/psi/core/kkrt_psi.cc
@@ -35,7 +35,7 @@
 namespace spu::psi {
 
 namespace {
-// constexpr size_t kPsiDataBatchSize = 1 << 10;
+
 constexpr size_t kPsiDataBatchSize = 1024;
 constexpr size_t kStashSize = 0;
 constexpr size_t kCuckooHashNum = 3;

--- a/libspu/psi/core/kkrt_psi.cc
+++ b/libspu/psi/core/kkrt_psi.cc
@@ -221,14 +221,14 @@ void KkrtPsiSend(const std::shared_ptr<yacl::link::Context>& link_ctx,
     if (c01 == 1) {
       uint8_t* encode_pos =
           encode_buf.data<uint8_t>() +
-          (input_permute[i] * kkrt_psi_options.cuckoo_hash_num + 1) *
+          (input_permute_inv[i] * kkrt_psi_options.cuckoo_hash_num + 1) *
               encode_size;
       prg.Fill(absl::MakeSpan(encode_pos, encode_size));
     }
     if (c02 == 1) {
       uint8_t* encode_pos =
           encode_buf.data<uint8_t>() +
-          (input_permute[i] * kkrt_psi_options.cuckoo_hash_num + 2) *
+          (input_permute_inv[i] * kkrt_psi_options.cuckoo_hash_num + 2) *
               encode_size;
       prg.Fill(absl::MakeSpan(encode_pos, encode_size));
     }

--- a/libspu/psi/utils/cipher_store.cc
+++ b/libspu/psi/utils/cipher_store.cc
@@ -152,7 +152,7 @@ void CachedCsvCipherStore::SavePeer(
   }
 }
 
-std::vector<uint64_t> CachedCsvCipherStore::FinalizeAndComputeIndices(
+std::vector<size_t> CachedCsvCipherStore::FinalizeAndComputeIndices(
     size_t bucket_size) {
   if (!self_read_only_) {
     self_out_->Flush();
@@ -161,8 +161,8 @@ std::vector<uint64_t> CachedCsvCipherStore::FinalizeAndComputeIndices(
 
   SPDLOG_INFO("Begin FinalizeAndComputeIndices");
 
-  std::unordered_set<uint64_t> indices_set;
-  std::vector<uint64_t> indices;
+  std::unordered_set<size_t> indices_set;
+  std::vector<size_t> indices;
 
   std::vector<std::string> ids = {cipher_id_};
   CsvBatchProvider peer_provider(peer_csv_path_, ids);
@@ -181,14 +181,14 @@ std::vector<uint64_t> CachedCsvCipherStore::FinalizeAndComputeIndices(
     size_t compare_size = (batch_peer_data.size() + compare_thread_num_ - 1) /
                           compare_thread_num_;
 
-    std::vector<std::vector<uint64_t>> result(compare_thread_num_);
+    std::vector<std::vector<size_t>> result(compare_thread_num_);
 
     auto compare_proc = [&](int idx) -> void {
-      uint64_t begin = idx * compare_size;
-      uint64_t end =
+      size_t begin = idx * compare_size;
+      size_t end =
           std::min<size_t>(batch_peer_data.size(), begin + compare_size);
 
-      for (uint64_t i = begin; i < end; i++) {
+      for (size_t i = begin; i < end; i++) {
         auto search_ret = self_data_.find(batch_peer_data[i]);
         if (search_ret != self_data_.end()) {
           result[idx].push_back(search_ret->second);

--- a/libspu/psi/utils/cipher_store.h
+++ b/libspu/psi/utils/cipher_store.h
@@ -131,7 +131,7 @@ class CachedCsvCipherStore : public ICipherStore {
     }
   }
 
-  std::vector<uint64_t> FinalizeAndComputeIndices(size_t bucket_size);
+  std::vector<size_t> FinalizeAndComputeIndices(size_t bucket_size);
 
  private:
   std::unique_ptr<io::OutputStream> self_out_;


### PR DESCRIPTION
reference libPSI issue57:
The collision handling code in KkrtPsiSender seems not working. · Issue [#57](https://code.alipay.com/secretflow/ppu/issues/57) · osu-crypto/libPSI (github.com)