### PR TITLE
add labeled ECDH PSI as PIR

### DIFF
--- a/libspu/pir/trivial_symmetric_pir/BUILD.bazel
+++ b/libspu/pir/trivial_symmetric_pir/BUILD.bazel
@@ -1,0 +1,52 @@
+load("//bazel:spu.bzl", "spu_cc_library", "spu_cc_test")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+
+package(default_visibility = ["//visibility:public"])
+
+spu_cc_library(
+    name = "trivial_spir_components",
+    srcs = ["trivial_spir_components.cc"],
+    hdrs = ["trivial_spir_components.h"],
+    linkopts = select({
+        "@bazel_tools//src/conditions:darwin": [],
+        "//conditions:default": ["-fopenmp"],
+    }),
+    deps = [
+        "//libspu/psi/core:communication",
+        "//libspu/core:prelude",
+        "//libspu/psi/core/ecdh_oprf:ecdh_oprf_selector",
+		"//libspu/psi/core:ecdh_psi",
+		"//libspu/psi/core:ecdh_oprf_psi",
+        "//libspu/psi/utils:batch_provider",
+        "//libspu/psi/utils:cipher_store",
+        "//libspu/psi/utils:ub_psi_cache",
+        "@com_google_absl//absl/strings",
+        "@yacl//yacl/link",
+        "@yacl//yacl/utils:parallel",
+    ] + select({
+        "@bazel_tools//src/conditions:darwin_x86_64": ["@local_homebrew_x64//:openmp"],
+        "@bazel_tools//src/conditions:darwin_arm64": ["@local_homebrew_arm64//:openmp"],
+        "//conditions:default": [],
+    }),
+)
+
+spu_cc_library(
+    name = "trivial_spir",
+    srcs = ["trivial_spir.cc"],
+    hdrs = [
+        "trivial_spir.h",
+    ],
+    deps = [
+		"trivial_spir_components",
+        "//libspu/pir:pir_cc_proto",
+        "//libspu/psi/core:ecdh_oprf_psi",
+        "//libspu/psi/utils:batch_provider",
+        "//libspu/psi/utils:cipher_store",
+        "//libspu/psi/utils:csv_checker",
+        "//libspu/psi/utils:csv_header_analyzer",
+        "//libspu/psi/utils:progress",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/time",
+    ],
+)

--- a/libspu/pir/trivial_symmetric_pir/README.md
+++ b/libspu/pir/trivial_symmetric_pir/README.md
@@ -1,0 +1,60 @@
+# Trivial Symmetric PIR
+
+- Author(s): [Huan Zou](https://github.com/zouhuan1215) 
+- Last updated:  July 29, 2023
+
+## Abstract
+
+This proposal implements trivial symmetric PIR:
+
+- **Trivial** refers to that the communication complexity between the server and the client is $O(n)$, where $n$ is the number of items in the server's database. Namely, the client has to download all the database items from the server.
+
+- **Symmetric** [[1]](#ref1) refers to that both the server's privacy is protected besides the client's privacy. That is, the server cannot learn which query the client asks for and the client cannot learn the database items beyond the ones it has asked for. 
+
+
+## 1. Protocol Description
+
+The basic idea of the protocol comes from [[2]](#ref2), which extends a PSI protocol to a labeled PSI protocol by utilizing the PSI's underlying oblivious pseudo-random function (OPRF). See the figure in the following.
+
+![Extending PSI to Labeled PSI](https://github.com/secretflow/spu/assets/41979254/d34face4-1baa-4941-9397-02504f2dcb21)
+
+This protocol chooses the ECDH PSI protocol from [[3]](#ref3) as the concrete PSI scheme to implement the labeled PSI. See the figure in the following.
+
+<img width="820" alt="Labeled ECDH PSI" src="https://github.com/secretflow/spu/assets/41979254/6f19279e-ee74-4766-abd4-c03db28c791b">
+
+In particular, this protocol does not compress the server's database items to improve communication efficiency. Because improving the communication complexity from linear to sublinear requires fully homomorphic encryption and polynomial interpolations (see [[4]](#ref4)), which may incur prohibitively expensive computation overheads.
+
+## 2. Security Proofs
+
+This protocol is secure in the honest-but-curious model, where the client and the server are assumed to follow the steps of the protocol honestly, but try to extract as much information as possible afterwards from the protocol transcript. 
+
+This protocol is based on the ECDH PSI scheme proposed by [[3]](#ref3) (Figure 1), whose security proof relies on random model under a one-more gap diffie-hellman assumption.
+The labeled version of the corresponding ECDH PSI scheme can be found at Section 5 of [[2]](#ref2), and whose security is shown by Theorem 3 of [[2]](#ref2). 
+
+## 3. Protocol Implementation
+
+The protocol implementation has the following layers:
+
+```
+[layer4] examples/trivial_spir_fullyonline // shows how to invoke the trivial_spir APIs
+↑
+[layer3] trivial_spir				// assembles the components to implement a pir server/client
+↑			
+[layer2] trivial_spir_components	// implements individual steps of trivial_spir
+↑
+[layer1] ecdh_oprf					// implements the ecdh oprf
+```
+
+There might be two improvements in the future: 
+- replace the `ecdh oprf` with more efficient oprf (e.g., the OT-based ones). This requires changes between layer1 and layer2.
+- implements pir as an online/offline paradigm. This requires changes between layer3 and layer4.
+
+## 4. References
+
+<a id="ref1">[1]</a>: Chengyu Lin, Zeyu Liu, Tal Malkin: XSPIR: Efficient Symmetrically Private Information Retrieval from Ring-LWE. ESORICS (1) 2022
+
+<a id="ref2">[2]</a>: Stanislaw Jarecki, Xiaomin Liu: Fast Secure Computation of Set Intersection. SCN 2010
+
+<a id="ref3">[3]</a>: Amanda Cristina Davi Resende, Diego F. Aranha: Faster Unbalanced Private Set Intersection. Financial Cryptography 2018
+
+<a id="ref4">[4]</a>: Kelong Cong, Radames Cruz Moreno, Mariana Botelho da Gama, Wei Dai, Ilia Iliashenko, Kim Laine, Michael Rosenberg: Labeled PSI from Homomorphic Encryption with Reduced Computation and Communication. CCS 2021

--- a/libspu/pir/trivial_symmetric_pir/examples/BUILD.bazel
+++ b/libspu/pir/trivial_symmetric_pir/examples/BUILD.bazel
@@ -1,0 +1,42 @@
+load("//bazel:spu.bzl", "spu_cc_binary", "spu_cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+spu_cc_binary(
+    name = "trivial_spir_fullyonline_client",
+    srcs = ["trivial_spir_fullyonline_client.cc"],
+    data = [
+        "//examples/data",
+    ],
+    linkopts = [
+        "-lm",
+    ],
+    deps = [
+        "//examples/cpp:utils",
+        "//libspu/pir/trivial_symmetric_pir:trivial_spir",
+        "//libspu/psi/utils",
+        "//libspu/psi/utils:cipher_store",
+        "//libspu/psi/utils:serialize",
+        "@com_google_absl//absl/strings",
+        "@yacl//yacl/crypto/utils:rand",
+    ],
+)
+
+spu_cc_binary(
+    name = "trivial_spir_fullyonline_server",
+    srcs = ["trivial_spir_fullyonline_server.cc"],
+    data = [
+        "//examples/data",
+    ],
+    linkopts = [
+        "-lm",
+    ],
+    deps = [
+        "//examples/cpp:utils",
+        "//libspu/pir/trivial_symmetric_pir:trivial_spir",
+        "//libspu/psi/utils",
+        "//libspu/psi/utils:serialize",
+        "@com_google_absl//absl/strings",
+        "@yacl//yacl/crypto/utils:rand",
+    ],
+)

--- a/libspu/pir/trivial_symmetric_pir/examples/trivial_spir_fullyonline_client.cc
+++ b/libspu/pir/trivial_symmetric_pir/examples/trivial_spir_fullyonline_client.cc
@@ -1,0 +1,68 @@
+// build 'trivial_spir_fullyonline_client'
+// > bazel build
+// //libspu/pir/trivial_symmetric_pir/examples:trivial_spir_fullyonline_client
+// -c opt
+//
+// To run the example, start terminals:
+// ./bazel-bin/libspu/pir/trivial_symmetric_pir/examples/trivial_spir_fullyonline_client -in_path ./examples/data/pir_client_data.csv -out_path ./dump/client_query_output.csv -key_columns id
+
+#include <chrono>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "absl/strings/str_split.h"
+#include "examples/cpp/utils.h"
+#include "spdlog/spdlog.h"
+#include "yacl/link/link.h"
+
+#include "libspu/pir/trivial_symmetric_pir/trivial_spir.h"
+
+#include "libspu/pir/pir.pb.h"
+
+llvm::cl::opt<std::string> InPathOpt(
+    "in_path", llvm::cl::init("data.csv"),
+    llvm::cl::desc("[in] pir data in file path"));
+
+llvm::cl::opt<std::string> KeyColumnsOpt("key_columns", llvm::cl::init("id"),
+                                         llvm::cl::desc("key columns"));
+
+llvm::cl::opt<std::string> OutPathOpt(
+    "out_path", llvm::cl::init("."),
+    llvm::cl::desc("[out] pir query output path"));
+
+int main(int argc, char **argv) {
+  llvm::cl::ParseCommandLineOptions(argc, argv);
+
+  SPDLOG_INFO("Trivial symmetric PIR, [mode]: fully online, [role]: client");
+  std::string ip0 = "127.0.0.1:17268";
+  std::string ip1 = "127.0.0.1:17269";
+  yacl::link::ContextDesc lctx_desc;
+  lctx_desc.parties.push_back({"id_0", ip0});
+  lctx_desc.parties.push_back({"id_1", ip1});
+  lctx_desc.recv_timeout_ms = 2 * 60 * 1000;
+  lctx_desc.connect_retry_times = 180;
+
+  auto link_ctx = yacl::link::FactoryBrpc().CreateContext(lctx_desc, 1);
+  link_ctx->ConnectToMesh();
+
+  std::vector<std::string> ids = absl::StrSplit(KeyColumnsOpt.getValue(), ',');
+
+  SPDLOG_INFO("in_path: {}", InPathOpt.getValue());
+  SPDLOG_INFO("id columns: {}", KeyColumnsOpt.getValue());
+
+  spu::pir::PirClientConfig config;
+
+  config.set_pir_protocol(spu::pir::PirProtocol::KEYWORD_PIR_LABELED_PSI);
+  config.set_input_path(InPathOpt.getValue());
+
+  config.mutable_key_columns()->Add(ids.begin(), ids.end());
+  config.set_output_path(OutPathOpt.getValue());
+
+  spu::pir::PirResultReport report =
+      spu::pir::TrivialSpirFullyOnlineClient(link_ctx, config);
+
+  SPDLOG_INFO("data count:{}", report.data_count());
+
+  return 0;
+}

--- a/libspu/pir/trivial_symmetric_pir/examples/trivial_spir_fullyonline_server.cc
+++ b/libspu/pir/trivial_symmetric_pir/examples/trivial_spir_fullyonline_server.cc
@@ -1,0 +1,87 @@
+// build 'trivial_spir_fullyonline_server'
+// > bazel build
+// //libspu/pir/trivial_symmetric_pir/examples:trivial_spir_fullyonline_server
+// -c opt
+//
+// To generate ecc oprf secret key, start terminals:
+// > dd if=/dev/urandom of=secret_key.bin-id bs=32 count=1
+// > dd if=/dev/urandom of=secret_key.bin-label bs=32 count=1
+//
+// To run the example, start terminals:
+// >
+// ./bazel-bin/libspu/pir/trivial_symmetric_pir/examples/trivial_spir_fullyonline_server -in_path ./examples/data/pir_server_data.csv -oprf_key_path ./dump/secret_key.bin  -key_columns id -label_length 72
+
+#include <chrono>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "absl/strings/str_split.h"
+#include "examples/cpp/utils.h"
+#include "spdlog/spdlog.h"
+#include "yacl/link/link.h"
+
+#include "libspu/pir/trivial_symmetric_pir/trivial_spir.h"
+
+#include "libspu/pir/pir.pb.h"
+
+llvm::cl::opt<std::string> InPathOpt(
+    "in_path", llvm::cl::init("data.csv"),
+    llvm::cl::desc("[in] pir data in file path"));
+
+llvm::cl::opt<std::string> OprfKeyPathOpt(
+    "oprf_key_path", llvm::cl::init("oprf_key.bin"),
+    llvm::cl::desc("[in] ecc oprf secretkey file path, 32bytes binary file"));
+
+llvm::cl::opt<std::string> KeyColumnsOpt("key_columns", llvm::cl::init("id"),
+                                         llvm::cl::desc("key columns"));
+
+llvm::cl::opt<int> LabelPadLengthOpt(
+    "label_length", llvm::cl::init(16),
+    llvm::cl::desc("the maximum byte length of the label (labels are "
+                   "expected to have the same lengths)"));
+
+namespace {
+constexpr uint32_t kLinkRecvTimeout = 30 * 60 * 1000;
+}
+
+int main(int argc, char **argv) {
+  llvm::cl::ParseCommandLineOptions(argc, argv);
+
+  SPDLOG_INFO("Trivial symmetric PIR, [mode]: fully online, [role]: server");
+  SPDLOG_INFO("in_path: {}", InPathOpt.getValue());
+  SPDLOG_INFO("id columns: {}", KeyColumnsOpt.getValue());
+  SPDLOG_INFO("oprf key path: {}", OprfKeyPathOpt.getValue());
+  std::string ip0 = "127.0.0.1:17268";
+  std::string ip1 = "127.0.0.1:17269";
+  yacl::link::ContextDesc lctx_desc;
+  lctx_desc.parties.push_back({"id_0", ip0});
+  lctx_desc.parties.push_back({"id_1", ip1});
+  lctx_desc.recv_timeout_ms = 2 * 60 * 1000;
+  lctx_desc.connect_retry_times = 180;
+
+  auto link_ctx = yacl::link::FactoryBrpc().CreateContext(lctx_desc, 0);
+  link_ctx->ConnectToMesh();
+
+  link_ctx->SetRecvTimeout(kLinkRecvTimeout);
+  SPDLOG_INFO("Link setup finished!");
+
+  std::vector<std::string> ids = absl::StrSplit(KeyColumnsOpt.getValue(), ',');
+
+  spu::pir::PirSetupConfig config;
+
+  config.set_pir_protocol(spu::pir::PirProtocol::KEYWORD_PIR_LABELED_PSI);
+  config.set_input_path(InPathOpt.getValue());
+
+  config.mutable_key_columns()->Add(ids.begin(), ids.end());
+
+  config.set_label_max_len(LabelPadLengthOpt.getValue());
+  config.set_oprf_key_path(OprfKeyPathOpt.getValue());
+
+  spu::pir::PirResultReport report =
+      spu::pir::TrivialSpirFullyOnlineServer(link_ctx, config);
+
+  SPDLOG_INFO("data count:{}", report.data_count());
+
+  return 0;
+}

--- a/libspu/pir/trivial_symmetric_pir/trivial_spir.cc
+++ b/libspu/pir/trivial_symmetric_pir/trivial_spir.cc
@@ -1,0 +1,302 @@
+#include "libspu/pir/trivial_symmetric_pir/trivial_spir.h"
+
+#include "yacl/io/rw/csv_writer.h"
+
+#include "libspu/pir/trivial_symmetric_pir/trivial_spir_components.h"
+#include "libspu/psi/utils/csv_header_analyzer.h"
+#include "libspu/psi/utils/serialize.h"
+#include "libspu/psi/utils/utils.h"
+
+namespace spu::pir {
+using duration_millis = std::chrono::duration<double, std::milli>;
+
+namespace {
+std::vector<uint8_t> ReadEcSecretKeyFile(const std::string& file_path) {
+  size_t file_byte_size = 0;
+  try {
+    file_byte_size = std::filesystem::file_size(file_path);
+  } catch (std::filesystem::filesystem_error& e) {
+    SPU_THROW("ReadEcSecretKeyFile {} Error: {}", file_path, e.what());
+  }
+  SPU_ENFORCE(file_byte_size == spu::psi::kEccKeySize,
+              "error format: key file bytes is not {}", spu::psi::kEccKeySize);
+
+  std::vector<uint8_t> secret_key(spu::psi::kEccKeySize);
+
+  auto in =
+      spu::psi::io::BuildInputStream(spu::psi::io::FileIoOptions(file_path));
+  in->Read(secret_key.data(), spu::psi::kEccKeySize);
+  in->Close();
+
+  return secret_key;
+}
+}  // namespace
+
+PirResultReport TrivialSpirFullyOnlineClient(
+    const std::shared_ptr<yacl::link::Context>& lctx,
+    const PirClientConfig& config) {
+  // ====================== [step 0] sync meta info =================
+  std::vector<std::string> id_columns;
+  id_columns.insert(id_columns.end(), config.key_columns().begin(),
+                    config.key_columns().end());
+
+  // recv the byte length of the label (including the delimiter)
+  size_t label_length = spu::psi::utils::DeserializeSize(
+      lctx->Recv(lctx->NextRank(), fmt::format("label_byte_count")));
+
+  // recv label columns
+  yacl::Buffer label_columns_buffer =
+      lctx->Recv(lctx->NextRank(), fmt::format("recv label columns name"));
+
+  // initialize the output csv file
+  std::vector<std::string> label_columns_name;
+  spu::psi::utils::DeserializeStrItems(label_columns_buffer,
+                                       &label_columns_name);
+  yacl::io::Schema s;
+  for (size_t i = 0; i < id_columns.size(); ++i) {
+    s.feature_types.push_back(yacl::io::Schema::STRING);
+  }
+  for (size_t i = 0; i < label_columns_name.size(); ++i) {
+    s.feature_types.push_back(yacl::io::Schema::STRING);
+  }
+  s.feature_names = id_columns;
+  s.feature_names.insert(s.feature_names.end(), label_columns_name.begin(),
+                         label_columns_name.end());
+
+  yacl::io::WriterOptions w_op;
+  w_op.file_schema = s;
+  std::string query_output_file = config.output_path();
+  auto out = spu::psi::io::BuildOutputStream(
+      spu::psi::io::FileIoOptions(query_output_file));
+  yacl::io::CsvWriter writer(w_op, std::move(out));
+  writer.Init();
+
+  auto step0_stats = lctx->GetStats();
+  float step0_recv_mBytes = step0_stats->recv_bytes / (1000 * 1000.0);
+  SPDLOG_INFO(
+      "[step0 ]*** Client and server sync the label column names, and label "
+      "byte count is {}; recv: {} mB",
+      label_length, step0_recv_mBytes);
+
+  // ==== [step 1] client receives server's OPRF values
+  spu::psi::EcdhOprfPsiOptions psi_options;
+  psi_options.link0 = lctx;
+  psi_options.link1 = lctx->Spawn();
+  psi_options.curve_type = spu::psi::CurveType::CURVE_FOURQ;
+  std::shared_ptr<LabeledEcdhOprfPsiClient> labeled_dh_oprf_psi_client =
+      std::make_shared<LabeledEcdhOprfPsiClient>(psi_options);
+
+  labeled_dh_oprf_psi_client->SetLabelLength(label_length);
+
+  const auto step2_start = std::chrono::system_clock::now();
+
+  std::vector<std::string> server_ids;
+  std::vector<std::string> server_labels;
+
+  labeled_dh_oprf_psi_client->RecvFinalEvaluatedItems(&server_ids,
+                                                      &server_labels);
+  SPU_ENFORCE(server_ids.size() == server_labels.size());
+
+  const auto step2_end = std::chrono::system_clock::now();
+  const duration_millis step2_duration = step2_end - step2_start;
+  auto step2_stats = lctx->GetStats();
+  float step2_recv_mBytes = step2_stats->recv_bytes / (1000 * 1000.0);
+  SPDLOG_INFO(
+      "[step2, offline]*** Client receives server's evaluated items; duration: "
+      "{} s, receives: {} mB",
+      step2_duration.count() / 1000, step2_recv_mBytes);
+
+  // ==== [step 2] client sends blinded items to the server
+  std::unique_ptr<spu::psi::CsvBatchProvider> client_batch_provider =
+      std::make_unique<spu::psi::CsvBatchProvider>(config.input_path(),
+                                                   id_columns);
+
+  const auto step3_start = std::chrono::system_clock::now();
+
+  std::vector<std::string> client_ids;
+  std::vector<std::string> client_blinded_ids;
+  size_t self_items_count = labeled_dh_oprf_psi_client->SendBlindedItems(
+      client_batch_provider, &client_ids);
+
+  const auto step3_end = std::chrono::system_clock::now();
+  const duration_millis step3_duration = step3_end - step3_start;
+
+  SPDLOG_INFO(
+      "[step3, online ]*** Client blinds its {} items and sends them to "
+      "server; duration: {} s",
+      client_ids.size(), step3_duration.count());
+
+  // ==== [step 5] client receives blinded evaluated items, unblinds them
+  const auto step5_start = std::chrono::system_clock::now();
+
+  std::vector<std::string> client_evaluated_ids;
+  std::vector<std::string> client_label_keys;
+  std::vector<std::string> client_blinded_evaluated_ids(client_ids.size());
+  std::vector<std::string> client_blinded_label_keys(client_ids.size());
+  labeled_dh_oprf_psi_client->RecvEvaluatedItems(&client_evaluated_ids,
+                                                 &client_label_keys);
+
+  const auto step5_end = std::chrono::system_clock::now();
+  const duration_millis step5_duration = step5_end - step5_start;
+  auto step5_stats = lctx->GetStats();
+  float step5_recv_mBytes =
+      (step5_stats->recv_bytes) / (1000 * 1000.0) - step2_recv_mBytes;
+  SPDLOG_INFO(
+      "[step5, online ]*** Client receives {} blinded OPRF values from the "
+      "server and unblinds them; duration: {} s, recv: {} mB",
+      self_items_count, step5_duration.count() / 1000, step5_recv_mBytes);
+
+  // === [step 6] client calculates the intersection and decrypt the label
+  const auto step6_start = std::chrono::system_clock::now();
+  std::vector<uint64_t> indices;
+  std::vector<std::string> labels;
+  std::shared_ptr<spu::psi::MemoryBatchProvider> server_batch_provider =
+      std::make_shared<spu::psi::MemoryBatchProvider>(server_ids,
+                                                      server_labels);
+  std::tie(indices, labels) =
+      labeled_dh_oprf_psi_client->FinalizeAndDecryptLabels(
+          server_batch_provider, client_evaluated_ids, client_label_keys);
+
+  const auto step6_end = std::chrono::system_clock::now();
+  const duration_millis step6_duration = step6_end - step6_start;
+
+  SPDLOG_INFO(
+      "[step6, online] Client calculates the intersection by comparing its and "
+      "the server's OPRF values; duration: {} s",
+      step6_duration.count() / 1000);
+
+  // ==== [step 7] client writes the query responses the file
+  SPU_ENFORCE(indices.size() == labels.size());
+  // sort labels by indices in ascending order
+  std::vector<int> indexes(indices.size());
+  std::iota(indexes.begin(), indexes.end(), 0);
+  std::sort(indexes.begin(), indexes.end(),
+            [&](int A, int B) -> bool { return indices[A] < indices[B]; });
+  std::vector<std::string> sorted_labels(labels.size());
+  for (size_t i = 0; i < indexes.size(); i++) {
+    sorted_labels[i] = labels[indexes[i]];
+  }
+
+  std::vector<std::vector<std::string>> query_label_results(
+      label_columns_name.size());
+  for (size_t i = 0; i < sorted_labels.size(); ++i) {
+    std::vector<std::string> result_labels =
+        absl::StrSplit(sorted_labels[i], ",");
+    SPU_ENFORCE(result_labels.size() == label_columns_name.size());
+    for (size_t j = 0; j < result_labels.size(); ++j) {
+      query_label_results[j].push_back(result_labels[j]);
+    }
+  }
+  yacl::io::ColumnVectorBatch batch;
+  batch.AppendCol(client_ids);
+  for (size_t i = 0; i < label_columns_name.size(); ++i) {
+    batch.AppendCol(query_label_results[i]);
+  }
+  writer.Add(batch);
+  writer.Close();
+
+  SPDLOG_INFO(
+      "****** Client gets {} query responses. Write the responses to file {}",
+      labels.size(), query_output_file);
+
+  PirResultReport report;
+  report.set_data_count(labels.size());
+
+  yacl::link::AllGather(lctx, "task finished", "client and server sync");
+  // wait the other party to exit safely
+  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+
+  return report;
+}
+
+// TODO: the PirServer uses the PirSetupConfig as pass-in params
+PirResultReport TrivialSpirFullyOnlineServer(
+    const std::shared_ptr<yacl::link::Context>& lctx,
+    const PirSetupConfig& config) {
+  std::vector<std::string> id_columns;
+  id_columns.insert(id_columns.end(), config.key_columns().begin(),
+                    config.key_columns().end());
+
+  // read column names from the csv file (note that column names can also be
+  // obtained by config.label_columns())
+  std::shared_ptr<spu::psi::CsvHeaderAnalyzer> csv_head_analyzer =
+      std::make_shared<spu::psi::CsvHeaderAnalyzer>(config.input_path(),
+                                                    id_columns);
+  std::vector<std::string> label_columns;
+  for (std::string field : csv_head_analyzer->headers()) {
+    if (std::find(id_columns.begin(), id_columns.end(), field) ==
+        id_columns.end()) {
+      label_columns.push_back(field);
+    }
+  }
+
+  // ==== [step 0]: sync meta info
+  SPU_ENFORCE(label_columns.size() > 0);
+  size_t label_length = config.label_max_len();
+
+  // send the label byte count
+  lctx->SendAsync(lctx->NextRank(),
+                  spu::psi::utils::SerializeSize(label_length),
+                  fmt::format("label_byte_count"));
+
+  // send labels column name
+  yacl::Buffer labels_buffer =
+      spu::psi::utils::SerializeStrItems(label_columns);
+  lctx->SendAsync(lctx->NextRank(), labels_buffer,
+                  fmt::format("send label columns name"));
+
+  SPDLOG_INFO("[ step0 ]*** Client and server sync the label column names");
+
+  // ==== [step 1] server evaluates its items and sends them to the client
+  spu::psi::EcdhOprfPsiOptions psi_options;
+  psi_options.link0 = lctx;
+  psi_options.link1 = lctx->Spawn();
+  psi_options.curve_type = spu::psi::CurveType::CURVE_FOURQ;
+  std::string id_key_path = fmt::format("{}-id", config.oprf_key_path());
+  std::string label_key_path = fmt::format("{}-label", config.oprf_key_path());
+  std::vector<uint8_t> id_server_private_key = ReadEcSecretKeyFile(id_key_path);
+  std::vector<uint8_t> label_server_private_key =
+      ReadEcSecretKeyFile(label_key_path);
+
+  std::shared_ptr<LabeledEcdhOprfPsiServer> labeled_dh_oprf_psi_server =
+      std::make_shared<LabeledEcdhOprfPsiServer>(
+          psi_options, id_server_private_key, label_server_private_key,
+          label_length);
+
+  const auto step1_start = std::chrono::system_clock::now();
+  std::shared_ptr<spu::psi::IBatchProvider> batch_provider =
+      std::make_shared<spu::psi::CsvBatchProvider>(config.input_path(),
+                                                   id_columns, label_columns);
+  size_t self_items_count =
+      labeled_dh_oprf_psi_server->FullEvaluateAndSend(batch_provider);
+
+  const auto step1_end = std::chrono::system_clock::now();
+  const duration_millis step1_duration = step1_end - step1_start;
+  SPDLOG_INFO(
+      "[step1, offline ]*** Server evaluates and sends {} items; duration: {} "
+      "s",
+      self_items_count, step1_duration.count() / 1000);
+
+  // ==== [step 4] server receives the blinded items, evaluates and sends back
+  const auto step4_start = std::chrono::system_clock::now();
+
+  labeled_dh_oprf_psi_server->RecvBlindAndSendEvaluate();
+
+  const auto step4_end = std::chrono::system_clock::now();
+  const duration_millis step4_duration = step4_end - step4_start;
+  auto step4_stats = lctx->GetStats();
+  SPDLOG_INFO(
+      "[step4, online ]*** Server receives client's blinded items, evaluates "
+      "them and sends back to the client; duration: {} s, receives {} mB",
+      step4_duration.count(), step4_stats->recv_bytes / (1000 * 1000.0));
+
+  PirResultReport report;
+  report.set_data_count(self_items_count);
+
+  yacl::link::AllGather(lctx, "task finished", "client and server sync");
+  // wait the other party to exit safely
+  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+
+  return report;
+}
+}  // namespace spu::pir

--- a/libspu/pir/trivial_symmetric_pir/trivial_spir.h
+++ b/libspu/pir/trivial_symmetric_pir/trivial_spir.h
@@ -1,0 +1,14 @@
+#pragma once
+#include "yacl/link/link.h"
+
+#include "libspu/pir/pir.pb.h"
+
+namespace spu::pir {
+PirResultReport TrivialSpirFullyOnlineServer(
+    const std::shared_ptr<yacl::link::Context>& lctx,
+    const PirSetupConfig& config);
+
+PirResultReport TrivialSpirFullyOnlineClient(
+    const std::shared_ptr<yacl::link::Context>& lctx,
+    const PirClientConfig& config);
+}

--- a/libspu/pir/trivial_symmetric_pir/trivial_spir_components.cc
+++ b/libspu/pir/trivial_symmetric_pir/trivial_spir_components.cc
@@ -1,0 +1,494 @@
+#include "libspu/pir/trivial_symmetric_pir/trivial_spir_components.h"
+
+#include <omp.h>
+
+#include <algorithm>
+#include <chrono>
+#include <future>
+#include <unordered_set>
+#include <utility>
+
+#include "absl/strings/escaping.h"
+#include "yacl/crypto/tools/prg.h"
+#include "yacl/utils/parallel.h"
+#include "yacl/utils/serialize.h"
+
+#include "libspu/core/prelude.h"
+#include "libspu/psi/core/communication.h"
+#include "libspu/psi/cryptor/ecc_utils.h"
+#include "libspu/psi/utils/ub_psi_cache.h"
+
+namespace spu::pir {
+namespace {
+std::string OneTimePad(std::string& key, std::string& item) {
+  // extract the first 16 bytes of the key as the PRG seed
+  uint128_t seed = 0;
+  for (int i = 0; i < 16; i++) {
+    seed = seed | (((uint128_t)key[i]) << (120 - 8 * i));
+  }
+  yacl::crypto::Prg<uint8_t> prg;
+  prg.SetSeed(seed);
+  std::vector<uint8_t> c(item.size());
+  // std::cout << "label plaintext length is: " << item.size() << std::endl;
+  for (size_t i = 0; i < item.size(); i++) {
+    c[i] = item[i] ^ prg();
+  }
+  std::string s(c.begin(), c.end());
+  return s;
+}
+
+std::string EncryptLabel(std::string& oprf_item, std::string& label) {
+  return OneTimePad(oprf_item, label);
+}
+
+std::string DecryptLabel(std::string& oprf_item, std::string& label_cipher) {
+  return OneTimePad(oprf_item, label_cipher);
+}
+}  // namespace
+
+size_t LabeledEcdhOprfPsiServer::FullEvaluateAndSend(
+    const std::shared_ptr<spu::psi::IBatchProvider>& batch_provider) {
+  size_t items_count = 0;
+  size_t batch_count = 1;
+  size_t id_compare_length = oprf_server_id_->GetCompareLength();
+  size_t label_cipher_length = label_length_;
+
+  bool stop_flag = false;
+  omp_lock_t lck_read, lck_send;
+
+  omp_init_lock(&lck_read);
+  omp_init_lock(&lck_send);
+
+  int tid;
+  batch_count = 0;
+  std::vector<std::string> batch_ids;
+  std::vector<std::string> batch_labels;
+  spu::psi::PsiDataBatch batch;
+  size_t i;
+  size_t local_batch_count;
+  int nthreads = omp_get_num_threads();
+  int mcpus = omp_get_num_procs();
+  SPDLOG_INFO("omp_get_num_threads:{} cpus:{}", nthreads, mcpus);
+  omp_set_num_threads(mcpus);
+
+#pragma omp parallel private(tid, nthreads, i, batch_ids, batch_labels, batch, \
+                             local_batch_count)                                \
+    shared(lck_read, lck_send, batch_count, items_count, id_compare_length,    \
+           label_cipher_length, stop_flag)
+  {
+    tid = omp_get_thread_num();
+    if ((tid == 0) && (batch_count == 0)) {
+      nthreads = omp_get_num_threads();
+      SPDLOG_INFO("tid:{} omp_get_num_threads:{}", tid, nthreads);
+    }
+    while (!stop_flag) {
+      omp_set_lock(&lck_read);
+
+      if (stop_flag) {
+        omp_unset_lock(&lck_read);
+        break;
+      }
+      std::tie(batch_ids, batch_labels) =
+          batch_provider->ReadNextBatchWithLabel(options_.batch_size);
+
+      batch.is_last_batch = batch_ids.empty();
+
+      if (batch_ids.empty()) {
+        stop_flag = true;
+      } else {
+        items_count += batch_ids.size();
+        batch_count++;
+        if ((batch_count % 1000) == 0) {
+          SPDLOG_INFO("batch_count:{}", batch_count);
+        }
+        local_batch_count = batch_count;
+      }
+
+      omp_unset_lock(&lck_read);
+
+      if (batch_ids.size() == 0) {
+        break;
+      }
+
+      batch.flatten_bytes.reserve(batch_ids.size() *
+                                  (id_compare_length + label_cipher_length));
+
+      // std::string
+      batch.flatten_bytes = oprf_server_id_->SimpleEvaluate(batch_ids[0]);
+      std::string oprf_label = oprf_server_label_->SimpleEvaluate(batch_ids[0]);
+      std::string label_cipher = EncryptLabel(oprf_label, batch_labels[0]);
+      batch.flatten_bytes.append(label_cipher);
+      for (i = 1; i < batch_ids.size(); i++) {
+        std::string masked_id = oprf_server_id_->SimpleEvaluate(batch_ids[i]);
+        batch.flatten_bytes.append(masked_id);
+
+        std::string oprf_label =
+            oprf_server_label_->SimpleEvaluate(batch_ids[i]);
+        std::string label_cipher = EncryptLabel(oprf_label, batch_labels[i]);
+        batch.flatten_bytes.append(label_cipher);
+      }
+
+      omp_set_lock(&lck_send);
+
+      // Send x^a and the label cipher encrypted with x^b
+      options_.link0->SendAsync(
+          options_.link0->NextRank(), batch.Serialize(),
+          fmt::format("LabeledEcdhOprfPSI:FinalEvaluatedItems:{}",
+                      local_batch_count));
+
+      omp_unset_lock(&lck_send);
+    }
+  }
+
+  batch.is_last_batch = true;
+  batch.flatten_bytes.resize(0);
+  options_.link0->SendAsync(
+      options_.link0->NextRank(), batch.Serialize(),
+      fmt::format("LabeledEcdhOprfPSI last batch,FinalEvaluatedItems:{}",
+                  batch_count));
+
+  SPDLOG_INFO("{} finished, batch_count={} items_count={}", __func__,
+              batch_count, items_count);
+
+  return items_count;
+}
+
+void LabeledEcdhOprfPsiClient::RecvFinalEvaluatedItems(
+    std::vector<std::string>* server_ids,
+    std::vector<std::string>* server_labels) {
+  SPDLOG_INFO("Begin Recv FinalEvaluatedItems items");
+
+  size_t batch_count = 0;
+  while (true) {
+    const auto tag =
+        fmt::format("LabeledEcdhOprfPSI:FinalEvaluatedItems:{}", batch_count);
+
+    // Fetch y^b.
+    spu::psi::PsiDataBatch masked_batch = spu::psi::PsiDataBatch::Deserialize(
+        options_.link0->Recv(options_.link0->NextRank(), tag));
+
+    if (masked_batch.is_last_batch) {
+      SPDLOG_INFO("{} Last batch triggered, batch_count={}", __func__,
+                  batch_count);
+      break;
+    }
+
+    size_t label_cipher_length_ = label_length_;
+    size_t item_length_ = compare_length_ + label_cipher_length_;
+    SPU_ENFORCE(masked_batch.flatten_bytes.length() % item_length_ == 0);
+    size_t num_items = masked_batch.flatten_bytes.length() / item_length_;
+
+    std::vector<std::string> evaluated_items(num_items);
+    (*server_ids).reserve(num_items);
+    (*server_labels).reserve(num_items);
+
+    for (size_t idx = 0; idx < num_items; ++idx) {
+      (*server_ids)
+          .emplace_back(masked_batch.flatten_bytes.substr(idx * item_length_,
+                                                          compare_length_));
+      (*server_labels)
+          .emplace_back(masked_batch.flatten_bytes.substr(
+              idx * item_length_ + compare_length_, label_cipher_length_));
+    }
+
+    batch_count++;
+  }
+  SPDLOG_INFO("End Recv FinalEvaluatedItems items");
+}
+
+size_t LabeledEcdhOprfPsiClient::SendBlindedItems(
+    const std::unique_ptr<spu::psi::CsvBatchProvider>& batch_provider,
+    std::vector<std::string>* client_ids) {
+  size_t batch_count = 0;
+  size_t items_count = 0;
+
+  SPDLOG_INFO("Begin Send BlindedItems items");
+
+  while (true) {
+    auto items = batch_provider->ReadNextBatch(options_.batch_size);
+
+    spu::psi::PsiDataBatch blinded_batch;
+    blinded_batch.is_last_batch = items.empty();
+
+    const auto tag =
+        fmt::format("LabeledEcdhOprfPSI:BlindItems:{}", batch_count);
+
+    if (blinded_batch.is_last_batch) {
+      SPDLOG_INFO("{} Last batch triggered, batch_count={}", __func__,
+                  batch_count);
+
+      options_.link1->SendAsync(options_.link1->NextRank(),
+                                blinded_batch.Serialize(), tag);
+      break;
+    }
+
+    for (size_t i = 0; i < items.size(); ++i) {
+      (*client_ids).emplace_back(items[i]);
+    }
+
+    std::vector<std::shared_ptr<spu::psi::IEcdhOprfClient>> oprf_clients(
+        items.size());
+    std::vector<std::string> blinded_items(items.size());
+
+    // yacl::parallel_for(0, items.size(), 1, [&](int64_t begin, int64_t end) {
+    //   for (int64_t idx = begin; idx < end; ++idx) {
+    //     if (oprf_client_ == nullptr) {
+    //       std::shared_ptr<spu::psi::IEcdhOprfClient> oprf_client_ptr =
+    //           spu::psi::CreateEcdhOprfClient(options_.oprf_type,
+    //           options_.curve_type);
+
+    //       oprf_clients[idx] = oprf_client_ptr;
+    //     } else {
+    //       oprf_clients[idx] = oprf_client_;
+    //     }
+    //     blinded_items[idx] = oprf_clients[idx]->Blind(items[idx]);
+    //   }
+    // });
+
+    // if the client has a large number of queries, parallel_for should be used
+    for (size_t idx = 0; idx < items.size(); ++idx) {
+      if (oprf_client_ == nullptr) {
+        std::shared_ptr<spu::psi::IEcdhOprfClient> oprf_client_ptr =
+            spu::psi::CreateEcdhOprfClient(options_.oprf_type,
+                                           options_.curve_type);
+
+        oprf_clients[idx] = oprf_client_ptr;
+      } else {
+        oprf_clients[idx] = oprf_client_;
+      }
+      blinded_items[idx] = oprf_clients[idx]->Blind(items[idx]);
+    }
+
+    blinded_batch.flatten_bytes.reserve(items.size() * ec_point_length_);
+
+    for (uint64_t idx = 0; idx < items.size(); ++idx) {
+      blinded_batch.flatten_bytes.append(blinded_items[idx]);
+    }
+
+    // push to oprf_client_queue_
+    if (oprf_client_ == nullptr) {
+      std::unique_lock<std::mutex> lock(mutex_);
+      queue_push_cv_.wait(lock, [&] {
+        return (oprf_client_queue_.size() < options_.window_size);
+      });
+      oprf_client_queue_.push(std::move(oprf_clients));
+      queue_pop_cv_.notify_one();
+      // SPDLOG_INFO("push to queue size:{}", oprf_client_queue_.size());
+    }
+
+    options_.link1->SendAsync(options_.link1->NextRank(),
+                              blinded_batch.Serialize(), tag);
+
+    items_count += blinded_items.size();
+    batch_count++;
+  }
+  SPDLOG_INFO("{} finished, batch_count={} items_count={}", __func__,
+              batch_count, items_count);
+
+  return items_count;
+}
+
+void LabeledEcdhOprfPsiServer::RecvBlindAndSendEvaluate() {
+  size_t batch_count = 0;
+
+  size_t ec_point_length = oprf_server_id_->GetEcPointLength();
+
+  while (true) {
+    const auto tag =
+        fmt::format("LabeledEcdhOprfPSI:BlindItems:{}", batch_count);
+    spu::psi::PsiDataBatch blinded_batch = spu::psi::PsiDataBatch::Deserialize(
+        options_.link1->Recv(options_.link1->NextRank(), tag));
+
+    spu::psi::PsiDataBatch evaluated_batch;
+    evaluated_batch.is_last_batch = blinded_batch.is_last_batch;
+
+    const auto tag_send =
+        fmt::format("LabeledEcdhOprfPSI:EvaluatedItems:{}", batch_count);
+
+    if (blinded_batch.is_last_batch) {
+      SPDLOG_INFO("{} Last batch triggered, batch_count={}", __func__,
+                  batch_count);
+
+      options_.link1->SendAsync(options_.link1->NextRank(),
+                                evaluated_batch.Serialize(), tag_send);
+      break;
+    }
+
+    // Fetch blinded x^r.
+    SPU_ENFORCE(blinded_batch.flatten_bytes.size() % ec_point_length == 0);
+    size_t num_items = blinded_batch.flatten_bytes.size() / ec_point_length;
+
+    std::vector<std::string> blinded_items(num_items);
+    for (size_t idx = 0; idx < num_items; ++idx) {
+      blinded_items[idx] = blinded_batch.flatten_bytes.substr(
+          idx * ec_point_length, ec_point_length);
+    }
+
+    evaluated_batch.flatten_bytes.reserve(2 * num_items * ec_point_length);
+
+    // (x^r)^a, for comparing id
+    std::vector<std::string> evaluated_items_id =
+        oprf_server_id_->Evaluate(blinded_items);
+    // (x^r)^b, for calculating the key to decrypt the label
+    std::vector<std::string> evaluated_items_label =
+        oprf_server_label_->Evaluate(blinded_items);
+    for (size_t idx = 0; idx < num_items; ++idx) {
+      evaluated_batch.flatten_bytes.append(evaluated_items_id[idx]);
+      evaluated_batch.flatten_bytes.append(evaluated_items_label[idx]);
+    }
+
+    options_.link1->SendAsync(options_.link1->NextRank(),
+                              evaluated_batch.Serialize(), tag_send);
+
+    batch_count++;
+  }
+  SPDLOG_INFO("{} finished, batch_count={}", __func__, batch_count);
+}
+
+void LabeledEcdhOprfPsiClient::RecvEvaluatedItems(
+    std::vector<std::string>* client_evaluated_ids,
+    std::vector<std::string>* client_label_keys) {
+  SPDLOG_INFO("Begin Recv EvaluatedItems items");
+
+  size_t batch_count = 0;
+
+  while (true) {
+    const auto tag =
+        fmt::format("LabeledEcdhOprfPSI:EvaluatedItems:{}", batch_count);
+    spu::psi::PsiDataBatch masked_batch = spu::psi::PsiDataBatch::Deserialize(
+        options_.link1->Recv(options_.link1->NextRank(), tag));
+    // Fetch evaluate y^rs.
+
+    if (masked_batch.is_last_batch) {
+      SPDLOG_INFO("{} Last batch triggered, batch_count={}", __func__,
+                  batch_count);
+      break;
+    }
+
+    SPU_ENFORCE(masked_batch.flatten_bytes.size() % (2 * ec_point_length_) ==
+                0);
+    size_t num_items =
+        masked_batch.flatten_bytes.size() / (2 * ec_point_length_);
+
+    std::vector<std::string> blinded_evaluated_items_id(num_items);
+    std::vector<std::string> blinded_evaluated_items_label(num_items);
+    for (size_t idx = 0; idx < num_items; ++idx) {
+      blinded_evaluated_items_id[idx] = masked_batch.flatten_bytes.substr(
+          idx * (2 * ec_point_length_), ec_point_length_);
+      blinded_evaluated_items_label[idx] = masked_batch.flatten_bytes.substr(
+          idx * (2 * ec_point_length_) + ec_point_length_, ec_point_length_);
+    }
+
+    std::vector<std::shared_ptr<spu::psi::IEcdhOprfClient>> oprf_clients;
+
+    // get oprf_clients
+    if (oprf_client_ == nullptr) {
+      std::unique_lock<std::mutex> lock(mutex_);
+      queue_pop_cv_.wait(lock, [&] { return (!oprf_client_queue_.empty()); });
+
+      oprf_clients = std::move(oprf_client_queue_.front());
+      oprf_client_queue_.pop();
+      queue_push_cv_.notify_one();
+    } else {
+      oprf_clients.resize(num_items);
+      for (size_t i = 0; i < oprf_clients.size(); ++i) {
+        oprf_clients[i] = oprf_client_;
+      }
+    }
+
+    SPU_ENFORCE(oprf_clients.size() == num_items,
+                "EcdhOprfClient should not be nullptr");
+
+    // yacl::parallel_for(0, num_items, 1, [&](int64_t begin, int64_t end) {
+    //   for (int64_t idx = begin; idx < end; ++idx) {
+    //     (*client_evaluated_ids).emplace_back(oprf_clients[idx]->Finalize(blinded_evaluated_items_id[idx]));
+    //     (*client_label_keys).emplace_back(oprf_clients[idx]->Finalize(blinded_evaluated_items_label[idx]));
+    //   }
+    // });
+
+    for (size_t idx = 0; idx < num_items; ++idx) {
+      (*client_evaluated_ids)
+          .emplace_back(
+              oprf_clients[idx]->Finalize(blinded_evaluated_items_id[idx]));
+      (*client_label_keys)
+          .emplace_back(
+              oprf_clients[idx]->Finalize(blinded_evaluated_items_label[idx]));
+    }
+
+    batch_count++;
+  }
+  SPDLOG_INFO("End Recv EvaluatedItems");
+}
+
+std::pair<std::vector<uint64_t>, std::vector<std::string>>
+LabeledEcdhOprfPsiClient::FinalizeAndDecryptLabels(
+    const std::shared_ptr<spu::psi::MemoryBatchProvider>& server_batch_provider,
+    const std::vector<std::string>& client_evaluated_ids,
+    const std::vector<std::string>& client_label_keys) {
+  std::vector<uint64_t> indices;
+  std::vector<std::string> labels;
+  size_t batch_count = 0;
+  size_t compare_thread_num = omp_get_num_procs();
+
+  while (true) {
+    std::vector<std::string> batch_server_ids;
+    std::vector<std::string> batch_server_labels;
+
+    std::tie(batch_server_ids, batch_server_labels) =
+        server_batch_provider->ReadNextBatchWithLabel(options_.batch_size);
+    if (batch_server_ids.empty()) {
+      SPDLOG_INFO("{} Last batch triggered, batch_count={}", __func__,
+                  batch_count);
+      break;
+    }
+    SPU_ENFORCE(batch_server_ids.size() == batch_server_labels.size());
+
+    size_t compare_size =
+        (batch_server_ids.size() + compare_thread_num - 1) / compare_thread_num;
+
+    std::vector<std::vector<uint64_t>> batch_result_indice(compare_thread_num);
+    std::vector<std::vector<std::string>> batch_result_label(
+        compare_thread_num);
+
+    auto compare_proc = [&](int idx) -> void {
+      uint64_t begin = idx * compare_size;
+      uint64_t end =
+          std::min<uint64_t>(batch_server_ids.size(), begin + compare_size);
+      for (uint64_t i = begin; i < end; ++i) {
+        auto it = std::find(client_evaluated_ids.begin(),
+                            client_evaluated_ids.end(), batch_server_ids[i]);
+        if (it != client_evaluated_ids.end()) {
+          uint64_t index = it - client_evaluated_ids.begin();
+          // begin to decrypt the label
+          std::string label_key = client_label_keys[index];
+          std::string label = DecryptLabel(label_key, batch_server_labels[i]);
+          // the index also corresponds to the indice of the client's input csv
+          batch_result_indice[idx].emplace_back(index);
+          batch_result_label[idx].emplace_back(label);
+        }
+      }
+    };
+    std::vector<std::future<void>> f_compare(compare_thread_num);
+    for (size_t i = 0; i < compare_thread_num; i++) {
+      f_compare[i] = std::async(compare_proc, i);
+    }
+
+    for (size_t i = 0; i < compare_thread_num; i++) {
+      f_compare[i].get();
+    }
+
+    for (size_t i = 0; i < compare_thread_num; i++) {
+      auto indice = batch_result_indice[i];
+      indices.insert(indices.end(), indice.begin(), indice.end());
+      auto label = batch_result_label[i];
+      labels.insert(labels.end(), label.begin(), label.end());
+    }
+
+    batch_count++;
+
+    // SPDLOG_INFO("GetIndices batch count:{}, item_index:{}", batch_count,
+    //             item_index);
+  }
+  return std::make_pair(indices, labels);
+}
+}  // namespace spu::pir

--- a/libspu/pir/trivial_symmetric_pir/trivial_spir_components.h
+++ b/libspu/pir/trivial_symmetric_pir/trivial_spir_components.h
@@ -1,0 +1,144 @@
+// Copyright 2022 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <queue>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "yacl/base/byte_container_view.h"
+#include "yacl/link/link.h"
+
+#include "libspu/psi/core/ecdh_oprf/ecdh_oprf.h"
+#include "libspu/psi/core/ecdh_oprf/ecdh_oprf_selector.h"
+// #include "libspu/psi/core/ecdh_psi.h"
+#include "libspu/psi/core/ecdh_oprf_psi.h"
+#pragma once
+
+#include "yacl/crypto/tools/prg.h"
+
+#include "libspu/psi/utils/batch_provider.h"
+#include "libspu/psi/utils/cipher_store.h"
+#include "libspu/psi/utils/ub_psi_cache.h"
+
+namespace spu::pir {
+class LabeledEcdhOprfPsiServer {
+ public:
+  explicit LabeledEcdhOprfPsiServer(const spu::psi::EcdhOprfPsiOptions& options)
+      : options_(options),
+        oprf_server_id_(
+            CreateEcdhOprfServer(options.oprf_type, options.curve_type)),
+        oprf_server_label_(
+            CreateEcdhOprfServer(options.oprf_type, options.curve_type)) {
+    label_length_ = 0;
+  }
+
+  LabeledEcdhOprfPsiServer(const spu::psi::EcdhOprfPsiOptions& options,
+                           yacl::ByteContainerView id_private_key,
+                           yacl::ByteContainerView label_private_key,
+                           size_t label_length)
+      : options_(options),
+        oprf_server_id_(CreateEcdhOprfServer(id_private_key, options.oprf_type,
+                                             options.curve_type)),
+        oprf_server_label_(CreateEcdhOprfServer(
+            label_private_key, options.oprf_type, options.curve_type)),
+        label_length_(label_length) {}
+
+  size_t FullEvaluateAndSend(
+      const std::shared_ptr<spu::psi::IBatchProvider>& batch_provider);
+
+  void RecvBlindAndSendEvaluate();
+
+  std::array<uint8_t, spu::psi::kEccKeySize> GetIDPrivateKey() {
+    return oprf_server_id_->GetPrivateKey();
+  }
+
+  std::array<uint8_t, spu::psi::kEccKeySize> GetLabelPrivateKey() {
+    return oprf_server_label_->GetPrivateKey();
+  }
+
+  size_t GetIDCompareLength() { return oprf_server_id_->GetCompareLength(); }
+
+  void SetLabelLength(size_t label_byte_count) {
+    label_length_ = label_byte_count;
+  }
+
+ private:
+  spu::psi::EcdhOprfPsiOptions options_;
+
+  std::shared_ptr<spu::psi::IEcdhOprfServer> oprf_server_id_;
+  std::shared_ptr<spu::psi::IEcdhOprfServer> oprf_server_label_;
+
+  size_t label_length_;
+};
+
+class LabeledEcdhOprfPsiClient {
+ public:
+  explicit LabeledEcdhOprfPsiClient(const spu::psi::EcdhOprfPsiOptions& options)
+      : options_(options) {
+    std::shared_ptr<spu::psi::IEcdhOprfClient> oprf_client =
+        spu::psi::CreateEcdhOprfClient(options.oprf_type, options.curve_type);
+    compare_length_ = oprf_client->GetCompareLength();
+    ec_point_length_ = oprf_client->GetEcPointLength();
+    label_length_ = 0;
+  }
+
+  explicit LabeledEcdhOprfPsiClient(const spu::psi::EcdhOprfPsiOptions& options,
+                                    yacl::ByteContainerView private_key)
+      : options_(options) {
+    oprf_client_ = spu::psi::CreateEcdhOprfClient(private_key, options.oprf_type,
+                                        options.curve_type);
+    compare_length_ = oprf_client_->GetCompareLength();
+    ec_point_length_ = oprf_client_->GetEcPointLength();
+    label_length_ = 0;
+  }
+
+  void SetLabelLength(size_t label_byte_count) {
+    label_length_ = label_byte_count;
+  }
+  void RecvFinalEvaluatedItems(std::vector<std::string>* server_ids,
+                               std::vector<std::string>* server_labels);
+
+  size_t SendBlindedItems(
+      const std::unique_ptr<spu::psi::CsvBatchProvider>& batch_provider,
+      std::vector<std::string>* client_ids);
+
+  void RecvEvaluatedItems(std::vector<std::string>* client_ids,
+                          std::vector<std::string>* client_labels);
+
+  std::pair<std::vector<uint64_t>, std::vector<std::string>>
+  FinalizeAndDecryptLabels(
+      const std::shared_ptr<spu::psi::MemoryBatchProvider>& server_batch_provider,
+      const std::vector<std::string>& client_ids,
+      const std::vector<std::string>& client_labels);
+
+ private:
+  spu::psi::EcdhOprfPsiOptions options_;
+
+  std::mutex mutex_;
+  std::condition_variable queue_push_cv_;
+  std::condition_variable queue_pop_cv_;
+  std::queue<std::vector<std::shared_ptr<spu::psi::IEcdhOprfClient>>> oprf_client_queue_;
+  std::shared_ptr<spu::psi::IEcdhOprfClient> oprf_client_ = nullptr;
+
+  size_t compare_length_;
+  size_t ec_point_length_;
+  size_t label_length_;
+};
+
+}


### PR DESCRIPTION
# 1. Protocol Description

This newly added private information retrieval (PIR) protocol has the following properties: 
1. the server does not learn which query the client asks for
2. the client does not learn the responses to the queries not queried by it
3. the client needs to download $O(n)$ items from the server, where $n$ refers to the number of items in the server's database. **That is, this is a trivial PIR protocol**

The basic idea of the protocol is to extend a private set intersection (PSI) to a labeled PSI protocol by utilizing the PSI's underlying oblivious pseudo-random function (OPRF). See the figure in the following.
![Extending PSI to Labeled PSI](https://github.com/secretflow/spu/assets/41979254/d34face4-1baa-4941-9397-02504f2dcb21)

This PR chooses the ECDH PSI as the concrete PSI scheme to implement the labeled PSI. See the figure in the following.
<img width="820" alt="Labeled ECDH PSI" src="https://github.com/secretflow/spu/assets/41979254/6f19279e-ee74-4766-abd4-c03db28c791b">

In particular, this PR does not compress the server's database items to improve communication efficiency. 
Because improving the communication complexity from linear to sublinear requires fully homomorphic encryption and polynomial interpolations, which may incur prohibitively expensive computation overheads.

# 2. Protocol Implementation

The framework of this PR is almost the same as the implementation of `UbPsiServer / UbPsiClient`, except for two major differences:

1. the `LabeledPsiServer` has two ECDH keys: one is for evaluating the ID and the other is for generating the symmetric key of encrypting the ID's corresponding label. See file `libspu/psi/core/ecdh_oprf_psi.cc`
2. A `one-time pad` encryption is introduced to encrypt the label. See file `libspu/psi/core/ecdh_oprf_psi.cc`

# 3. TODOs

1. **调用接口**。当前的 PIR 实现是通过 PSI 的接口 ( protocol=13）暴露给上层应用程序的，感觉这样不太合适，请问有更好的调用方式吗？此外，这个 PIR 接口的入参需要指定 2  个 ECDH key 文件，输出结果需要写到一个 csv 文件中。
2. **one-time pad 加密**。当前实现是采用哈希 label key 然后再异或 label 实现的，更安全的方式是用 label key 作为流密码的种子，生成伪随机比特串，然后再去异或 label。请问 SPU 有流密码的相关包吗？
3. **单元测试**。当前实现还没写单元测试。请问有参考的代码或者文档吗？
4. **分开写在线和离线阶段**。当前实现将在线和离线阶段都写到了一起。


