### PR TITLE
使用 SPU 逻辑回归算法功能性增强[add L1 & elasticnet penalty]

### DIFF
--- a/sml/linear_model/emulations/logistic_emul.py
+++ b/sml/linear_model/emulations/logistic_emul.py
@@ -33,13 +33,14 @@ def emul_LogisticRegression(mode: emulation.Mode.MULTIPROCESS):
     # Test SGDClassifier
     def proc(x, y, penalty):
         model = LogisticRegression(
-            epochs=3,
+            epochs=1,
             learning_rate=0.1,
             batch_size=8,
             solver="sgd",
             penalty=penalty,
             sig_type="sr",
-            l2_norm=1.0,
+            C=1.0,
+            l1_ratio=0.5,
             class_weight=None,
             multi_class="binary",
         )

--- a/sml/linear_model/emulations/logistic_emul.py
+++ b/sml/linear_model/emulations/logistic_emul.py
@@ -27,14 +27,17 @@ from sml.linear_model.logistic import LogisticRegression
 
 
 def emul_LogisticRegression(mode: emulation.Mode.MULTIPROCESS):
+    penalty_list = ["l1", "l2", "elasticnet"]
+    print(f"penalty_list={penalty_list}")
+
     # Test SGDClassifier
-    def proc(x, y):
+    def proc(x, y, penalty):
         model = LogisticRegression(
             epochs=3,
             learning_rate=0.1,
             batch_size=8,
             solver="sgd",
-            penalty="l2",
+            penalty=penalty,
             sig_type="sr",
             l2_norm=1.0,
             class_weight=None,
@@ -66,12 +69,13 @@ def emul_LogisticRegression(mode: emulation.Mode.MULTIPROCESS):
             X.values, y.values.reshape(-1, 1)
         )  # X, y should be two-dimension array
 
-        # Run
-        result = emulator.run(proc)(X_spu, y_spu)
-        print("Predict result prob: ", result[0])
-        print("Predict result label: ", result[1])
-
-        print("ROC Score: ", roc_auc_score(y.values, result[0]))
+        for i in range(len(penalty_list)):
+            penalty = penalty_list[i]
+            # Run
+            result = emulator.run(proc, static_argnums=(2,))(X_spu, y_spu, penalty)
+            # print("Predict result prob: ", result[0])
+            # print("Predict result label: ", result[1])
+            print(f"{penalty} ROC Score: {roc_auc_score(y.values, result[0])}")
 
     finally:
         emulator.down()

--- a/sml/linear_model/logistic.py
+++ b/sml/linear_model/logistic.py
@@ -98,10 +98,11 @@ class LogisticRegression:
         assert learning_rate > 0, f"learning_rate should >0"
         assert batch_size > 0, f"batch_size should >0"
         assert solver == 'sgd', "only support sgd solver for now"
+        assert C > 0, f"C should >0"
         if penalty == Penalty.Elastic:
             assert (
                 0 <= l1_ratio <= 1
-            ), f"elastic_norm should in `[0, 1]` if use Elastic penalty"
+            ), f"l1_ratio should in `[0, 1]` if use Elastic penalty"
         assert penalty in [
             e.value for e in Penalty
         ], f"penalty should in {[e.value for e in Penalty]}, but got {penalty}"
@@ -152,7 +153,7 @@ class LogisticRegression:
             err = pred - y_slice
             grad = jnp.matmul(jnp.transpose(x_slice), err)
 
-            if self._penalty is not None:
+            if self._penalty != Penalty.NONE:
                 w_with_zero_bias = jnp.resize(w, (num_feat, 1))
                 w_with_zero_bias = jnp.concatenate(
                     (w_with_zero_bias, jnp.zeros((1, 1))),
@@ -167,7 +168,6 @@ class LogisticRegression:
                     jnp.sign(w_with_zero_bias) * self._l1_ratio * 1.0 / self._C
                     + w_with_zero_bias * (1 - self._l1_ratio) * 1.0 / self._C
                 )
-
             else:
                 reg = 0
 

--- a/sml/linear_model/tests/logistic_test.py
+++ b/sml/linear_model/tests/logistic_test.py
@@ -35,14 +35,17 @@ class UnitTests(unittest.TestCase):
             3, spu_pb2.ProtocolKind.ABY3, spu_pb2.FieldType.FM64
         )
 
+        penalty_list = ["l1", "l2", "elasticnet"]
+        print(f"penalty_list={penalty_list}")
+
         # Test SGDClassifier
-        def proc(x, y):
+        def proc(x, y, penalty):
             model = LogisticRegression(
                 epochs=3,
                 learning_rate=0.1,
                 batch_size=8,
                 solver="sgd",
-                penalty="l2",
+                penalty=penalty,
                 sig_type="sr",
                 l2_norm=1.0,
                 class_weight=None,
@@ -62,14 +65,15 @@ class UnitTests(unittest.TestCase):
         X = scalar.fit_transform(X)
         X = pd.DataFrame(X, columns=cols)
 
-        # Run
-        result = spsim.sim_jax(sim, proc)(
-            X.values, y.values.reshape(-1, 1)
-        )  # X, y should be two-dimension array
-        print("Predict result prob: ", result[0])
-        print("Predict result label: ", result[1])
-
-        print("ROC Score: ", roc_auc_score(y.values, result[0]))
+        for i in range(len(penalty_list)):
+            penalty = penalty_list[i]
+            # Run
+            result = spsim.sim_jax(sim, proc, static_argnums=(2,))(
+                X.values, y.values.reshape(-1, 1), penalty
+            )  # X, y should be two-dimension array
+            # print("Predict result prob: ", result[0])
+            # print("Predict result label: ", result[1])
+            print(f"{penalty} ROC Score: {roc_auc_score(y.values, result[0])}")
 
 
 if __name__ == "__main__":

--- a/sml/linear_model/tests/logistic_test.py
+++ b/sml/linear_model/tests/logistic_test.py
@@ -41,13 +41,14 @@ class UnitTests(unittest.TestCase):
         # Test SGDClassifier
         def proc(x, y, penalty):
             model = LogisticRegression(
-                epochs=3,
+                epochs=1,
                 learning_rate=0.1,
                 batch_size=8,
                 solver="sgd",
                 penalty=penalty,
                 sig_type="sr",
-                l2_norm=1.0,
+                C=1.0,
+                l1_ratio=0.5,
                 class_weight=None,
                 multi_class="binary",
             )


### PR DESCRIPTION
# Pull Request

## What problem does this PR solve?
add L1 & elasticnet penalty

Issue Number: Fixed #252

## Possible side effects?

- Performance:
test:
```
Ran 1 test in 30.356s

OK
penalty_list=['l1', 'l2', 'elasticnet']
l1 ROC Score: 0.9923365572644153
l2 ROC Score: 0.9919665979599387
elasticnet ROC Score: 0.9921912161090851
```
emulations
```
l1 ROC Score: 0.9923233444321125
l2 ROC Score: 0.9919665979599387
elasticnet ROC Score: 0.9921780032767824
[2023-10-10 03:11:33,316] Shutdown multiprocess cluster...
```

- Backward compatibility:
