### PR TITLE
Fix the negative log-likelihood loss in jax_lr.py.

### DIFF
--- a/examples/python/ml/jax_lr/jax_lr.py
+++ b/examples/python/ml/jax_lr/jax_lr.py
@@ -44,9 +44,8 @@ def predict(x, w, b):
 
 def loss(x, y, w, b):
     pred = predict(x, w, b)
-    label_prob = pred * y + (1 - pred) * (1 - y)
-    return -jnp.mean(jnp.log(label_prob))
-
+    return -jnp.mean(y * jnp.log(pred) + (1 - y) * jnp.log(1 - pred))
+    
 
 class LogitRegression:
     def __init__(self, n_epochs=10, n_iters=10, step_size=0.1):


### PR DESCRIPTION
# Pull Request

## What problem does this PR solve?

This pull request addresses an issue with the implementation of the negative log-likelihood loss function.
The original code incorrectly applied the logarithmic operation to an intermediate variable label_prob instead of directly to the predicted probability values pred.
The updated code corrects this mistake by applying the log function to the correct terms (pred) and (1 - pred) as per the standard definition of binary cross-entropy loss.

## Possible side effects?

- Performance: There should be no significant change in performance because the modification is straightforward and does not introduce additional computations.

- Backward compatibility: The change is internal to the loss function computation and should not affect backward compatibility. It will simply provide a correct implementation of the loss calculation for training models.
