### PR TITLE
[sml] add chi2 stats in jax

### DIFF
--- a/sml/feature_selection/BUILD.bazel
+++ b/sml/feature_selection/BUILD.bazel
@@ -1,4 +1,4 @@
-# Copyright 2023 Ant Group Co., Ltd.
+# Copyright 2024 Ant Group Co., Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sml/feature_selection/BUILD.bazel
+++ b/sml/feature_selection/BUILD.bazel
@@ -1,0 +1,22 @@
+# Copyright 2023 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_python//python:defs.bzl", "py_library")
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "univariate_selection",
+    srcs = ["univariate_selection.py"],
+)

--- a/sml/feature_selection/emulations/BUILD.bazel
+++ b/sml/feature_selection/emulations/BUILD.bazel
@@ -1,4 +1,4 @@
-# Copyright 2023 Ant Group Co., Ltd.
+# Copyright 2024 Ant Group Co., Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sml/feature_selection/emulations/BUILD.bazel
+++ b/sml/feature_selection/emulations/BUILD.bazel
@@ -1,0 +1,26 @@
+# Copyright 2023 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_python//python:defs.bzl", "py_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+py_binary(
+    name = "chi2_emul",
+    srcs = ["chi2_emul.py"],
+    deps = [
+        "//sml/feature_selection:univariate_selection",
+        "//sml/utils:emulation",
+    ],
+)

--- a/sml/feature_selection/emulations/chi2_emul.py
+++ b/sml/feature_selection/emulations/chi2_emul.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Ant Group Co., Ltd.
+# Copyright 2024 Ant Group Co., Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import os
 import sys
 import time

--- a/sml/feature_selection/emulations/chi2_emul.py
+++ b/sml/feature_selection/emulations/chi2_emul.py
@@ -1,0 +1,95 @@
+# Copyright 2023 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+import time
+
+import numpy as np
+from sklearn.datasets import load_iris
+from sklearn.feature_selection import chi2 as chi2_sklearn
+
+# Add the library directory to the path
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../../'))
+import sml.utils.emulation as emulation
+from sml.feature_selection.univariate_selection import chi2
+
+
+def emul_Chi2(mode: emulation.Mode.MULTIPROCESS):
+    print("start chi2 stats emulation")
+
+    def load_data():
+        x, y = load_iris(return_X_y=True)
+        return x, y
+
+    def proc(x, y, num_class, max_iter, compute_p_value):
+        chi2_stats, p_value = chi2(x, y, num_class, max_iter, compute_p_value)
+        return chi2_stats, p_value
+
+    try:
+        # bandwidth and latency only work for docker mode
+        emulator = emulation.Emulator(
+            emulation.CLUSTER_ABY3_3PC, mode, bandwidth=300, latency=20
+        )
+        emulator.up()
+        # load data
+        x, y = load_data()
+        label_lst = np.unique(y)
+        num_class = len(label_lst)
+        max_iter = 1
+        compute_p_value = True
+        # compare with sklearn
+        start_time = time.time()
+        sklearn_chi2_stats, sklearn_p_value = chi2_sklearn(x, y)
+        end_time = time.time()
+        print("=========================")
+        print(f"Running time in SKlearn: {end_time - start_time:.3f}s")
+        print("=========================")
+        # mark these data to be protected in SPU
+        X_spu, y_spu = emulator.seal(x, y)
+        # run
+        start_time = time.time()
+        chi2_stats, p_value = emulator.run(proc, static_argnums=(2, 3, 4))(
+            X_spu, y_spu, num_class, max_iter, compute_p_value
+        )
+        end_time = time.time()
+        print("=========================")
+        print(f"Running time in SPU: {end_time - start_time:.3f}s")
+        print("=========================")
+
+        # print chi2 stats
+        print("Chi2 stats result:")
+        print(chi2_stats)
+        print("Sklearn chi2 stats result:")
+        print(sklearn_chi2_stats)
+        assert np.allclose(
+            sklearn_chi2_stats,
+            sklearn_chi2_stats,
+            rtol=1.0e-5,
+            atol=1.0e-2,
+        )
+        print("P value result:")
+        print(p_value)
+        print("Sklearn p value result:")
+        print(sklearn_p_value)
+        assert np.allclose(
+            p_value, sklearn_p_value, rtol=1.0e-5, atol=1.0e-2, equal_nan=True
+        )
+    except Exception as e:
+        print(e)
+    finally:
+        emulator.down()
+
+
+if __name__ == "__main__":
+    emul_Chi2(emulation.Mode.MULTIPROCESS)

--- a/sml/feature_selection/tests/BUILD.bazel
+++ b/sml/feature_selection/tests/BUILD.bazel
@@ -1,4 +1,4 @@
-# Copyright 2023 Ant Group Co., Ltd.
+# Copyright 2024 Ant Group Co., Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sml/feature_selection/tests/BUILD.bazel
+++ b/sml/feature_selection/tests/BUILD.bazel
@@ -1,0 +1,27 @@
+# Copyright 2023 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_python//python:defs.bzl", "py_test")
+
+package(default_visibility = ["//visibility:public"])
+
+py_test(
+    name = "chi2_test",
+    srcs = ["chi2_test.py"],
+    deps = [
+        "//sml/feature_selection:univariate_selection",
+        "//spu:init",
+        "//spu/utils:simulation",
+    ],
+)

--- a/sml/feature_selection/tests/chi2_test.py
+++ b/sml/feature_selection/tests/chi2_test.py
@@ -1,0 +1,69 @@
+# Copyright 2023 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+import unittest
+
+import numpy as np
+from sklearn.datasets import load_iris
+from sklearn.feature_selection import chi2 as chi2_sklearn
+
+import spu.spu_pb2 as spu_pb2
+import spu.utils.simulation as spsim
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../../'))
+from sml.feature_selection.univariate_selection import chi2
+
+
+class UnitTests(unittest.TestCase):
+    def test_chi2(self):
+        sim = spsim.Simulator.simple(
+            3, spu_pb2.ProtocolKind.ABY3, spu_pb2.FieldType.FM128
+        )
+
+        def proc(x, y, num_class, max_iter, compute_p_value):
+            chi2_stats, p_value = chi2(x, y, num_class, max_iter, compute_p_value)
+            return chi2_stats, p_value
+
+        # create dataset
+        x, y = load_iris(return_X_y=True)
+        label_lst = np.unique(y)
+        num_class = len(label_lst)
+        max_iter = 1
+        compute_p_value = True
+        chi2_stats, p_value = spsim.sim_jax(sim, proc, static_argnums=(2, 3, 4))(
+            x, y, num_class, max_iter, compute_p_value
+        )
+        sklearn_chi2_stats, sklearn_p_value = chi2_sklearn(x, y)
+        print("Chi2 stats result:")
+        print(chi2_stats)
+        print("Sklearn chi2 stats result:")
+        print(sklearn_chi2_stats)
+        assert np.allclose(
+            sklearn_chi2_stats,
+            sklearn_chi2_stats,
+            rtol=1.0e-5,
+            atol=1.0e-2,
+        )
+        print("P value result:")
+        print(p_value)
+        print("Sklearn p value result:")
+        print(sklearn_p_value)
+        assert np.allclose(
+            p_value, sklearn_p_value, rtol=1.0e-5, atol=1.0e-2, equal_nan=True
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sml/feature_selection/tests/chi2_test.py
+++ b/sml/feature_selection/tests/chi2_test.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Ant Group Co., Ltd.
+# Copyright 2024 Ant Group Co., Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,16 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import os
 import sys
 import unittest
 
 import numpy as np
-from sklearn.datasets import load_iris
-from sklearn.feature_selection import chi2 as chi2_sklearn
-
 import spu.spu_pb2 as spu_pb2
 import spu.utils.simulation as spsim
+from sklearn.datasets import load_iris
+from sklearn.feature_selection import chi2 as chi2_sklearn
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '../../../'))
 from sml.feature_selection.univariate_selection import chi2

--- a/sml/feature_selection/univariate_selection.py
+++ b/sml/feature_selection/univariate_selection.py
@@ -1,0 +1,199 @@
+import jax
+import jax.numpy as jnp
+
+
+def _sf(x, df, max_iter=3):
+    """
+    Calculates the survival function (1 - CDF) of the chi-squared distribution.
+
+    Parameters
+    ----------
+    x : array-like, shape (n_quantiles,)
+        The quantiles at which to compute the survival function.
+
+    df : int
+        The degrees of freedom of the chi-squared distribution. Must be positive.
+
+    max_iter : int, default=3
+        The maximum number of iterations for the numerical computation.
+
+    Returns
+    -------
+    result : array-like, shape (n_quantiles,)
+        The survival function evaluated at the given quantiles.
+
+    Notes
+    -----
+    The `max_iter` parameter is critical for the numerical stability of the computation. A high value can lead to overflow or underflow errors. Consider using a higher precision data type or reducing `max_iter` to ensure stability.
+    """
+    if df <= 0:
+        raise ValueError("Domain error, df must be positive")
+    condlist = [x < 0, x == 0, jnp.logical_or(x < 1, x < df)]
+    choicelist = [
+        jnp.ones_like(x),
+        jnp.zeros_like(x),
+        1 - _igam(0.5 * df, 0.5 * x, max_iter),
+    ]
+    result = jnp.select(
+        condlist, choicelist, default=_igamc(df * 0.5, x * 0.5, max_iter)
+    )
+    return result
+
+
+def _igam(a, x, max_iter=3):
+    """
+    Computes the regularized lower incomplete gamma function using a power series expansion for a given shape parameter.
+
+    Parameters
+    ----------
+    a : int
+        The shape parameter of the gamma function.
+
+    x : array-like, shape (n_quantiles,)
+        The quantiles at which to compute the incomplete gamma function.
+
+    max_iter : int, default=3
+        The maximum number of iterations for the numerical computation.
+
+    Returns
+    -------
+    ans : array-like, shape (n_quantiles,)
+        The regularized lower incomplete gamma function evaluated at the given quantiles.
+
+    Notes
+    -----
+    The `max_iter` parameter is crucial for the numerical stability of the computation. A high value can lead to overflow or underflow errors. It is recommended to use a higher precision data type or reduce the `max_iter` value to avoid such issues.
+    """
+    ax = jnp.power(x, a) * jnp.exp(-x) * jnp.exp(-jax.lax.lgamma(a))
+    # Power series
+    r = jnp.full_like(x, a)
+    c = jnp.ones_like(x)
+    ans = jnp.ones_like(x)
+
+    def loop_body(_, val):
+        r, c, ans = val
+        r += 1.0
+        c *= x / r
+        ans += c
+        return (r, c, ans)
+
+    init_val = (r, c, ans)
+    _, _, ans = jax.lax.fori_loop(0, max_iter, loop_body, init_val)
+    return ans * ax / a
+
+
+def _igamc(a, x, max_iter=3):
+    """
+    Computes the complementary regularized lower incomplete gamma function using a continued fraction representation for a given shape parameter.
+
+    Parameters
+    ----------
+    a : int
+        The shape parameter of the gamma function.
+
+    x : array-like, shape (n_quantiles,)
+        The quantiles at which to compute the complementary of incomplete gamma function.
+
+    max_iter : int, default=3
+        The maximum number of iterations for the numerical computation.
+
+    Returns
+    -------
+    ans : array-like, shape (n_quantiles,)
+        The complementary regularized lower incomplete gamma function evaluated at the given quantiles.
+
+    Notes
+    -----
+    The `max_iter` parameter is crucial for the numerical stability of the computation. A high value can lead to overflow or underflow errors. It is recommended to use a higher precision data type or reduce the `max_iter` value to avoid such issues.
+    """
+    # Compute ax = x**a * exp(-x) / Gamma(a)
+    ax = jnp.power(x, a) * jnp.exp(-x) * jnp.exp(-jax.lax.lgamma(a))
+    y = jnp.ones_like(x) - a
+    z = x + y + 1.0
+    c = jnp.zeros_like(x)
+    pkm2 = jnp.ones_like(x)
+    qkm2 = jnp.full_like(x, a)
+    pkm1 = x + 1.0
+    qkm1 = z * x
+    ans = pkm1 / qkm1
+
+    # Using Continued Fraction
+    def loop_body(_, val):
+        (c, y, z, pkm1, pkm2, qkm1, qkm2), ans = val
+        c += 1.0
+        y += 1.0
+        z += 2.0
+        yc = y * c
+        pk = pkm1 * z - pkm2 * yc
+        qk = qkm1 * z - qkm2 * yc
+        r = pk / qk
+        ans = r
+        pkm2 = pkm1
+        pkm1 = pk
+        qkm2 = qkm1
+        qkm1 = qk
+        return (c, y, z, pkm1, pkm2, qkm1, qkm2), ans
+
+    params = (c, y, z, pkm1, pkm2, qkm1, qkm2)
+    init_val = (params, ans)
+    params, ans = jax.lax.fori_loop(0, max_iter, loop_body, init_val)
+    return ans * ax
+
+
+def chi2(X, y, n_classes, max_iter=3, compute_p_value=False):
+    """
+    Performs a chi-squared test for independence between features and class labels.
+
+    Parameters
+    ----------
+    X : array-like, shape (n_samples, n_features)
+        The input feature matrix where each row represents a sample and each column a feature.
+
+    y : array-like, shape (n_samples,)
+        An array of class labels for the samples in `X`. Labels should be integers in the range [0, n_classes-1].
+
+    n_classes : int
+        The number of unique classes in the classification problem.
+
+    max_iter : int, default=3
+        The maximum number of iterations for the numerical computation of the p-value. This parameter is crucial for numerical stability and convergence.
+
+    compute_p_value : bool, default=False
+        Whether to compute the p-value alongside the chi-squared statistic.
+
+    Returns
+    -------
+    chi2_stats : array-like, shape (n_features,)
+        The chi-squared statistics computed for each feature.
+
+    p_value : array-like, shape (n_features,), optional
+        The p-values corresponding to each feature's chi-squared statistic. Returned only if `compute_p_value` is set to True.
+
+    Notes
+    -----
+    - The `max_iter` parameter should be set with consideration of the potential for numerical overflow or underflow. In cases where numerical stability is a concern, consider using a higher precision data type (e.g., Float128 if available) or reducing the `max_iter` value.
+    - The p value computation cost maybe expensive. For applications such as feature selection where only the chi-squared statistic is needed, it may be more efficient to set `compute_p_value` to False.
+    - The input `y` should be provided as a 1-dimensional array with class labels encoded as integers in the specified range.
+    """
+
+    # one hot encoding
+    y = jnp.eye(n_classes)[y]
+    X = jnp.array(X)
+    y = jnp.array(y)
+    feature_count = jnp.sum(X, axis=0)
+    class_prob = jnp.mean(y, axis=0)
+    # Calculate the observed frequency count
+    observed = jnp.dot(X.T, y)
+    expected = jnp.outer(feature_count, class_prob)
+    # Calculate the chi-squared statistic
+    chi2_stats = (observed - expected) ** 2 / expected
+    # Sum over class dimensions
+    chi2_stats = jnp.nansum(chi2_stats, axis=1)
+    # Degrees of freedom
+    df = n_classes - 1
+    p_value = None
+    if compute_p_value:
+        # Calculate the p-value for each feature
+        p_value = _sf(chi2_stats, df=df, max_iter=max_iter)
+        p_value = jnp.where(p_value < 0, 0, p_value)
+    return chi2_stats, p_value


### PR DESCRIPTION
# Pull Request

## What problem does this PR solve?
使用SPU实现chi2统计量的计算
Issue Number: Fixed #591 
## Possible side effects?
- Performance:
Test:
```
OK
Chi2 stats result:
[ 10.817831    3.7107298 116.31106    67.04839  ]
Sklearn chi2 stats result:
[ 10.81782088   3.7107283  116.31261309  67.0483602 ]
P value result:
[0.00416027 0.14996627 0.         0.        ]
Sklearn p value result:
[4.47651499e-03 1.56395980e-01 5.53397228e-26 2.75824965e-15]
```
Emulation:
```
=========================
Running time in Sklearn: 0.005s
=========================
Running time in SPU: 3.628s
=========================
Chi2 stats result:
[ 10.821831    3.7121124 116.352936   67.072624 ]
Sklearn chi2 stats result:
[ 10.81782088   3.7107283  116.31261309  67.0483602 ]
P value result:
[0.00415421 0.1498375  0.         0.        ]
Sklearn p value result:
[4.47651499e-03 1.56395980e-01 5.53397228e-26 2.75824965e-15]
[2024-04-25 12:54:47,659] Shutdown multiprocess cluster...
```
- Backward compatibility:

