### PR TITLE
[CHEETAH] Improve the B2A by 50% via collapse COTs

### DIFF
--- a/libspu/mpc/cheetah/ot/emp/ferret.cc
+++ b/libspu/mpc/cheetah/ot/emp/ferret.cc
@@ -433,6 +433,117 @@ struct EmpFerretOt::Impl {
   }
 
   template <typename T>
+  void SendCorrelatedMsgChosenChoice_Collapse(absl::Span<const T> corr,
+                                              absl::Span<T> output,
+                                              int bit_width, int num_level) {
+    size_t n = corr.size();
+    SPU_ENFORCE_EQ(n, output.size());
+    if (bit_width == 0) {
+      bit_width = 8 * sizeof(T);
+    }
+    SPU_ENFORCE(bit_width > 0 && bit_width <= (int)(8 * sizeof(T)),
+                "bit_width={} out-of-range T={} bits", bit_width,
+                sizeof(T) * 8);
+    SPU_ENFORCE(
+        num_level > 0 && (n % num_level) == 0 && (bit_width >= num_level),
+        "invalid num_level {}", num_level);
+
+    std::unique_ptr<OtBaseTyp[]> rcm_output(new OtBaseTyp[n]);
+
+    SendRandCorrelatedMsgChosenChoice(rcm_output.get(), n);
+
+    std::array<OtBaseTyp, 2 * kOTBatchSize> pad;
+    std::vector<T> corr_output(kOTBatchSize);
+
+    const size_t eltsize = 8 * sizeof(T);
+    const size_t collapse_size = n / num_level;
+    std::vector<T> packed_corr_output(kOTBatchSize);
+    for (size_t i = 0; i < n; i += kOTBatchSize) {
+      size_t this_batch = std::min(kOTBatchSize, n - i);
+      // NOTE(lwj) this batch might cross two collapse, but the bit_width should
+      // be fine since we decrease the bit_width along each collapse batch.
+      size_t this_batch_bw = bit_width - i / collapse_size;
+      bool packable = eltsize > this_batch_bw;
+
+      for (size_t j = 0; j < this_batch; ++j) {
+        pad[2 * j] = rcm_output[i + j];
+        pad[2 * j + 1] = rcm_output[i + j] ^ ferret_->Delta;
+      }
+
+      ferret_->mitccrh.template hash<kOTBatchSize, 2>(pad.data());
+
+      for (size_t j = 0; j < this_batch; ++j) {
+        output[i + j] = ConvFromBlock<T>(pad[2 * j]);
+        corr_output[j] = ConvFromBlock<T>(pad[2 * j + 1]);
+        corr_output[j] += corr[i + j] + output[i + j];
+      }
+
+      if (packable) {
+        size_t used =
+            ZipArray<T>({corr_output.data(), this_batch}, this_batch_bw,
+                        absl::MakeSpan(packed_corr_output));
+        SPU_ENFORCE(used == CeilDiv(this_batch * this_batch_bw, eltsize));
+        io_->send_data(packed_corr_output.data(), used * sizeof(T));
+      } else {
+        io_->send_data(corr_output.data(), sizeof(T) * this_batch);
+      }
+    }
+    io_->flush();
+  }
+
+  template <typename T>
+  void RecvCorrelatedMsgChosenChoice_Collapse(absl::Span<const uint8_t> choices,
+                                              absl::Span<T> output,
+                                              int bit_width, int num_level) {
+    size_t n = choices.size();
+    SPU_ENFORCE_EQ(n, output.size());
+    if (bit_width == 0) {
+      bit_width = 8 * sizeof(T);
+    }
+    SPU_ENFORCE(bit_width > 0 && bit_width <= (int)(8 * sizeof(T)),
+                "bit_width={} out-of-range T={} bits", bit_width,
+                sizeof(T) * 8);
+    SPU_ENFORCE(
+        num_level > 0 && (n % num_level) == 0 && (bit_width >= num_level),
+        "invalid num_level {}", num_level);
+
+    std::vector<OtBaseTyp> rcm_output(n);
+    RecvRandCorrelatedMsgChosenChoice(choices, absl::MakeSpan(rcm_output));
+
+    std::array<OtBaseTyp, kOTBatchSize> pad;
+    std::vector<T> corr_output(kOTBatchSize);
+
+    const size_t eltsize = 8 * sizeof(T);
+    const size_t collapse_size = n / num_level;
+    std::vector<T> packed_corr_output(kOTBatchSize);
+    for (size_t i = 0; i < n; i += kOTBatchSize) {
+      size_t this_batch = std::min(kOTBatchSize, n - i);
+      size_t this_batch_bw = bit_width - i / collapse_size;
+      bool packable = eltsize > this_batch_bw;
+
+      std::memcpy(pad.data(), rcm_output.data() + i,
+                  this_batch * sizeof(OtBaseTyp));
+      ferret_->mitccrh.template hash<kOTBatchSize, 1>(pad.data());
+
+      if (packable) {
+        size_t used = CeilDiv(this_batch * this_batch_bw, eltsize);
+        io_->recv_data(packed_corr_output.data(), sizeof(T) * used);
+        UnzipArray<T>({packed_corr_output.data(), used}, this_batch_bw,
+                      {corr_output.data(), this_batch});
+      } else {
+        io_->recv_data(corr_output.data(), sizeof(T) * this_batch);
+      }
+
+      for (size_t j = 0; j < this_batch; ++j) {
+        output[i + j] = ConvFromBlock<T>(pad[j]);
+        if (choices[i + j]) {
+          output[i + j] = corr_output[j] - output[i + j];
+        }
+      }
+    }
+  }
+
+  template <typename T>
   void SendCorrelatedMsgChosenChoice(absl::Span<const T> corr,
                                      absl::Span<T> output, int bit_width) {
     size_t n = corr.size();
@@ -844,52 +955,63 @@ size_t CheckBitWidth(size_t bw) {
   return bw;
 }
 
-#define DEF_SEND_RECV(T)                                                      \
-  void EmpFerretOt::SendCAMCC(absl::Span<const T> corr, absl::Span<T> output, \
-                              int bw) {                                       \
-    impl_->SendCorrelatedMsgChosenChoice<T>(corr, output, bw);                \
-  }                                                                           \
-  void EmpFerretOt::RecvCAMCC(absl::Span<const uint8_t> choices,              \
-                              absl::Span<T> output, int bw) {                 \
-    impl_->RecvCorrelatedMsgChosenChoice<T>(choices, output, bw);             \
-  }                                                                           \
-  void EmpFerretOt::SendRMRC(absl::Span<T> output0, absl::Span<T> output1,    \
-                             size_t bit_width) {                              \
-    bit_width = CheckBitWidth<T>(bit_width);                                  \
-    impl_->SendRandMsgRandChoice<T>(output0, output1, bit_width);             \
-  }                                                                           \
-  void EmpFerretOt::RecvRMRC(absl::Span<uint8_t> choices,                     \
-                             absl::Span<T> output, size_t bit_width) {        \
-    bit_width = CheckBitWidth<T>(bit_width);                                  \
-    impl_->RecvRandMsgRandChoice<T>(choices, output, bit_width);              \
-  }                                                                           \
-  void EmpFerretOt::SendCMCC(absl::Span<const T> msg_array, size_t N,         \
-                             size_t bit_width) {                              \
-    bit_width = CheckBitWidth<T>(bit_width);                                  \
-    if (N == 2) {                                                             \
-      impl_->SendChosenTwoMsgChosenChoice<T>(msg_array, bit_width);           \
-      return;                                                                 \
-    }                                                                         \
-    impl_->SendChosenMsgChosenChoice<T>(msg_array, N, bit_width);             \
-  }                                                                           \
-  void EmpFerretOt::RecvCMCC(absl::Span<const uint8_t> choices, size_t N,     \
-                             absl::Span<T> output, size_t bit_width) {        \
-    bit_width = CheckBitWidth<T>(bit_width);                                  \
-    if (N == 2) {                                                             \
-      impl_->RecvChosenTwoMsgChosenChoice<T>(choices, output, bit_width);     \
-      return;                                                                 \
-    }                                                                         \
-    impl_->RecvChosenMsgChosenChoice<T>(choices, N, output, bit_width);       \
-  }                                                                           \
-  void EmpFerretOt::SendRMCC(absl::Span<T> output0, absl::Span<T> output1,    \
-                             size_t bit_width) {                              \
-    bit_width = CheckBitWidth<T>(bit_width);                                  \
-    impl_->SendRMCC<T>(output0, output1, bit_width);                          \
-  }                                                                           \
-  void EmpFerretOt::RecvRMCC(absl::Span<const uint8_t> choices,               \
-                             absl::Span<T> output, size_t bit_width) {        \
-    bit_width = CheckBitWidth<T>(bit_width);                                  \
-    impl_->RecvRMCC<T>(choices, output, bit_width);                           \
+#define DEF_SEND_RECV(T)                                                       \
+  void EmpFerretOt::SendCAMCC(absl::Span<const T> corr, absl::Span<T> output,  \
+                              int bw) {                                        \
+    impl_->SendCorrelatedMsgChosenChoice<T>(corr, output, bw);                 \
+  }                                                                            \
+  void EmpFerretOt::RecvCAMCC(absl::Span<const uint8_t> choices,               \
+                              absl::Span<T> output, int bw) {                  \
+    impl_->RecvCorrelatedMsgChosenChoice<T>(choices, output, bw);              \
+  }                                                                            \
+  void EmpFerretOt::SendCAMCC_Collapse(                                        \
+      absl::Span<const T> corr, absl::Span<T> output, int bw, int num_level) { \
+    impl_->SendCorrelatedMsgChosenChoice_Collapse<T>(corr, output, bw,         \
+                                                     num_level);               \
+  }                                                                            \
+  void EmpFerretOt::RecvCAMCC_Collapse(absl::Span<const uint8_t> choices,      \
+                                       absl::Span<T> output, int bw,           \
+                                       int num_level) {                        \
+    impl_->RecvCorrelatedMsgChosenChoice_Collapse<T>(choices, output, bw,      \
+                                                     num_level);               \
+  }                                                                            \
+  void EmpFerretOt::SendRMRC(absl::Span<T> output0, absl::Span<T> output1,     \
+                             size_t bit_width) {                               \
+    bit_width = CheckBitWidth<T>(bit_width);                                   \
+    impl_->SendRandMsgRandChoice<T>(output0, output1, bit_width);              \
+  }                                                                            \
+  void EmpFerretOt::RecvRMRC(absl::Span<uint8_t> choices,                      \
+                             absl::Span<T> output, size_t bit_width) {         \
+    bit_width = CheckBitWidth<T>(bit_width);                                   \
+    impl_->RecvRandMsgRandChoice<T>(choices, output, bit_width);               \
+  }                                                                            \
+  void EmpFerretOt::SendCMCC(absl::Span<const T> msg_array, size_t N,          \
+                             size_t bit_width) {                               \
+    bit_width = CheckBitWidth<T>(bit_width);                                   \
+    if (N == 2) {                                                              \
+      impl_->SendChosenTwoMsgChosenChoice<T>(msg_array, bit_width);            \
+      return;                                                                  \
+    }                                                                          \
+    impl_->SendChosenMsgChosenChoice<T>(msg_array, N, bit_width);              \
+  }                                                                            \
+  void EmpFerretOt::RecvCMCC(absl::Span<const uint8_t> choices, size_t N,      \
+                             absl::Span<T> output, size_t bit_width) {         \
+    bit_width = CheckBitWidth<T>(bit_width);                                   \
+    if (N == 2) {                                                              \
+      impl_->RecvChosenTwoMsgChosenChoice<T>(choices, output, bit_width);      \
+      return;                                                                  \
+    }                                                                          \
+    impl_->RecvChosenMsgChosenChoice<T>(choices, N, output, bit_width);        \
+  }                                                                            \
+  void EmpFerretOt::SendRMCC(absl::Span<T> output0, absl::Span<T> output1,     \
+                             size_t bit_width) {                               \
+    bit_width = CheckBitWidth<T>(bit_width);                                   \
+    impl_->SendRMCC<T>(output0, output1, bit_width);                           \
+  }                                                                            \
+  void EmpFerretOt::RecvRMCC(absl::Span<const uint8_t> choices,                \
+                             absl::Span<T> output, size_t bit_width) {         \
+    bit_width = CheckBitWidth<T>(bit_width);                                   \
+    impl_->RecvRMCC<T>(choices, output, bit_width);                            \
   }
 
 DEF_SEND_RECV(uint8_t)

--- a/libspu/mpc/cheetah/ot/emp/ferret.h
+++ b/libspu/mpc/cheetah/ot/emp/ferret.h
@@ -101,6 +101,33 @@ class EmpFerretOt : public FerretOtInterface {
   void RecvCAMCC(absl::Span<const uint8_t> binary_choices,
                  absl::Span<uint128_t> output, int bit_width = 0) override;
 
+  // Run `num_level` of CAMCC concurrently while in the k-th the bit_width is
+  // bit_width_begin - k
+  void SendCAMCC_Collapse(absl::Span<const uint8_t> corr,
+                          absl::Span<uint8_t> output, int bit_width_begin,
+                          int num_level) override;
+  void SendCAMCC_Collapse(absl::Span<const uint32_t> corr,
+                          absl::Span<uint32_t> output, int bit_width_begin,
+                          int num_level) override;
+  void SendCAMCC_Collapse(absl::Span<const uint64_t> corr,
+                          absl::Span<uint64_t> output, int bit_width_begin,
+                          int num_level) override;
+  void SendCAMCC_Collapse(absl::Span<const uint128_t> corr,
+                          absl::Span<uint128_t> output, int bit_width_begin,
+                          int num_level) override;
+  void RecvCAMCC_Collapse(absl::Span<const uint8_t> binary_choices,
+                          absl::Span<uint8_t> output, int bit_width_begin,
+                          int num_level) override;
+  void RecvCAMCC_Collapse(absl::Span<const uint8_t> binary_choices,
+                          absl::Span<uint32_t> output, int bit_width_begin,
+                          int num_level) override;
+  void RecvCAMCC_Collapse(absl::Span<const uint8_t> binary_choices,
+                          absl::Span<uint64_t> output, int bit_width_begin,
+                          int num_level) override;
+  void RecvCAMCC_Collapse(absl::Span<const uint8_t> binary_choices,
+                          absl::Span<uint128_t> output, int bit_width_begin,
+                          int num_level) override;
+
   // Random Message Chosen Choice
   void SendRMCC(absl::Span<uint8_t> output0, absl::Span<uint8_t> output1,
                 size_t bit_width = 0) override;

--- a/libspu/mpc/cheetah/ot/ferret_ot_interface.h
+++ b/libspu/mpc/cheetah/ot/ferret_ot_interface.h
@@ -84,6 +84,33 @@ class FerretOtInterface {
   virtual void RecvCAMCC(absl::Span<const uint8_t> binary_choices,
                          absl::Span<uint128_t> output, int bit_width = 0) = 0;
 
+  // Run `num_level` of CAMCC concurrently while in the k-th the bit_width is
+  // bit_width_begin - k
+  virtual void SendCAMCC_Collapse(absl::Span<const uint8_t> corr,
+                                  absl::Span<uint8_t> output,
+                                  int bit_width_begin, int num_level) = 0;
+  virtual void SendCAMCC_Collapse(absl::Span<const uint32_t> corr,
+                                  absl::Span<uint32_t> output,
+                                  int bit_width_begin, int num_level) = 0;
+  virtual void SendCAMCC_Collapse(absl::Span<const uint64_t> corr,
+                                  absl::Span<uint64_t> output,
+                                  int bit_width_begin, int num_level) = 0;
+  virtual void SendCAMCC_Collapse(absl::Span<const uint128_t> corr,
+                                  absl::Span<uint128_t> output,
+                                  int bit_width_begin, int num_level) = 0;
+  virtual void RecvCAMCC_Collapse(absl::Span<const uint8_t> binary_choices,
+                                  absl::Span<uint8_t> output,
+                                  int bit_width_begin, int num_level) = 0;
+  virtual void RecvCAMCC_Collapse(absl::Span<const uint8_t> binary_choices,
+                                  absl::Span<uint32_t> output,
+                                  int bit_width_begin, int num_level) = 0;
+  virtual void RecvCAMCC_Collapse(absl::Span<const uint8_t> binary_choices,
+                                  absl::Span<uint64_t> output,
+                                  int bit_width_begin, int num_level) = 0;
+  virtual void RecvCAMCC_Collapse(absl::Span<const uint8_t> binary_choices,
+                                  absl::Span<uint128_t> output,
+                                  int bit_width_begin, int num_level) = 0;
+
   // Random Message Chosen Choice
   virtual void SendRMCC(absl::Span<uint8_t> output0,
                         absl::Span<uint8_t> output1, size_t bit_width = 0) = 0;

--- a/libspu/mpc/cheetah/ot/ot_util.cc
+++ b/libspu/mpc/cheetah/ot/ot_util.cc
@@ -16,6 +16,8 @@
 
 #include <numeric>
 
+#include "ot_util.h"
+
 #include "libspu/core/prelude.h"
 
 namespace spu::mpc::cheetah {
@@ -77,6 +79,83 @@ NdArrayRef OpenShare(const NdArrayRef &shr, ReduceOp op, size_t nbits,
     UnzipArray(absl::MakeConstSpan(opened), nbits, oup);
   });
   return out.reshape(shr.shape());
+}
+
+#ifdef __x86_64__
+#include <immintrin.h>
+#elif __aarch64__
+#include "sse2neon.h"
+#endif
+
+#define INP(x, y) inp[(x) * ncols / 8 + (y) / 8]
+#define OUT(x, y) out[(y) * nrows / 8 + (x) / 8]
+
+#ifdef __x86_64__
+__attribute__((target("sse2")))
+#endif
+void SseTranspose(uint8_t *out, uint8_t const *inp, uint64_t nrows, uint64_t ncols) {
+  uint64_t rr, cc;
+  int i, h;
+  union {
+    __m128i x;
+    uint8_t b[16];
+  } tmp;
+  __m128i vec;
+  SPU_ENFORCE(nrows % 8 == 0 && ncols % 8 == 0);
+
+  // Do the main body in 16x8 blocks:
+  for (rr = 0; rr + 16 <= nrows; rr += 16) {
+    for (cc = 0; cc < ncols; cc += 8) {
+      vec = _mm_set_epi8(INP(rr + 15, cc), INP(rr + 14, cc), INP(rr + 13, cc),
+                         INP(rr + 12, cc), INP(rr + 11, cc), INP(rr + 10, cc),
+                         INP(rr + 9, cc), INP(rr + 8, cc), INP(rr + 7, cc),
+                         INP(rr + 6, cc), INP(rr + 5, cc), INP(rr + 4, cc),
+                         INP(rr + 3, cc), INP(rr + 2, cc), INP(rr + 1, cc),
+                         INP(rr + 0, cc));
+      for (i = 8; --i >= 0; vec = _mm_slli_epi64(vec, 1))
+        *(uint16_t *)&OUT(rr, cc + i) = _mm_movemask_epi8(vec);
+    }
+  }
+  if (rr == nrows) return;
+
+  // The remainder is a block of 8x(16n+8) bits (n may be 0).
+  //  Do a PAIR of 8x8 blocks in each step:
+  if ((ncols % 8 == 0 && ncols % 16 != 0) ||
+      (nrows % 8 == 0 && nrows % 16 != 0)) {
+    // The fancy optimizations in the else-branch don't work if the above
+    // if-condition holds, so we use the simpler non-simd variant for that case.
+    for (cc = 0; cc + 16 <= ncols; cc += 16) {
+      for (i = 0; i < 8; ++i) {
+        tmp.b[i] = h = *(uint16_t const *)&INP(rr + i, cc);
+        tmp.b[i + 8] = h >> 8;
+      }
+      for (i = 8; --i >= 0; tmp.x = _mm_slli_epi64(tmp.x, 1)) {
+        OUT(rr, cc + i) = h = _mm_movemask_epi8(tmp.x);
+        OUT(rr, cc + i + 8) = h >> 8;
+      }
+    }
+  } else {
+    for (cc = 0; cc + 16 <= ncols; cc += 16) {
+      vec = _mm_set_epi16(*(uint16_t const *)&INP(rr + 7, cc),
+                          *(uint16_t const *)&INP(rr + 6, cc),
+                          *(uint16_t const *)&INP(rr + 5, cc),
+                          *(uint16_t const *)&INP(rr + 4, cc),
+                          *(uint16_t const *)&INP(rr + 3, cc),
+                          *(uint16_t const *)&INP(rr + 2, cc),
+                          *(uint16_t const *)&INP(rr + 1, cc),
+                          *(uint16_t const *)&INP(rr + 0, cc));
+      for (i = 8; --i >= 0; vec = _mm_slli_epi64(vec, 1)) {
+        OUT(rr, cc + i) = h = _mm_movemask_epi8(vec);
+        OUT(rr, cc + i + 8) = h >> 8;
+      }
+    }
+  }
+  if (cc == ncols) return;
+
+  //  Do the remaining 8x8 block:
+  for (i = 0; i < 8; ++i) tmp.b[i] = INP(rr + i, cc);
+  for (i = 8; --i >= 0; tmp.x = _mm_slli_epi64(tmp.x, 1))
+    OUT(rr, cc + i) = _mm_movemask_epi8(tmp.x);
 }
 
 }  // namespace spu::mpc::cheetah

--- a/libspu/mpc/cheetah/ot/ot_util.h
+++ b/libspu/mpc/cheetah/ot/ot_util.h
@@ -135,4 +135,9 @@ uint8_t BoolToU8(absl::Span<const uint8_t> bits);
 
 void U8ToBool(absl::Span<uint8_t> bits, uint8_t u8);
 
+// Taken from emp-tool
+// https://github.com/emp-toolkit/emp-tool/blob/master/emp-tool/utils/block.h#L113
+void SseTranspose(uint8_t *out, uint8_t const *inp, uint64_t nrows,
+                  uint64_t ncols);
+
 }  // namespace spu::mpc::cheetah

--- a/libspu/mpc/cheetah/ot/yacl/ferret.h
+++ b/libspu/mpc/cheetah/ot/yacl/ferret.h
@@ -101,6 +101,33 @@ class YaclFerretOt : public spu::mpc::cheetah::FerretOtInterface {
   void RecvCAMCC(absl::Span<const uint8_t> binary_choices,
                  absl::Span<uint128_t> output, int bit_width = 0) override;
 
+  // Run `num_level` of CAMCC concurrently while in the k-th the bit_width is
+  // bit_width_begin - k
+  void SendCAMCC_Collapse(absl::Span<const uint8_t> corr,
+                          absl::Span<uint8_t> output, int bit_width_begin,
+                          int num_level) override;
+  void SendCAMCC_Collapse(absl::Span<const uint32_t> corr,
+                          absl::Span<uint32_t> output, int bit_width_begin,
+                          int num_level) override;
+  void SendCAMCC_Collapse(absl::Span<const uint64_t> corr,
+                          absl::Span<uint64_t> output, int bit_width_begin,
+                          int num_level) override;
+  void SendCAMCC_Collapse(absl::Span<const uint128_t> corr,
+                          absl::Span<uint128_t> output, int bit_width_begin,
+                          int num_level) override;
+  void RecvCAMCC_Collapse(absl::Span<const uint8_t> binary_choices,
+                          absl::Span<uint8_t> output, int bit_width_begin,
+                          int num_level) override;
+  void RecvCAMCC_Collapse(absl::Span<const uint8_t> binary_choices,
+                          absl::Span<uint32_t> output, int bit_width_begin,
+                          int num_level) override;
+  void RecvCAMCC_Collapse(absl::Span<const uint8_t> binary_choices,
+                          absl::Span<uint64_t> output, int bit_width_begin,
+                          int num_level) override;
+  void RecvCAMCC_Collapse(absl::Span<const uint8_t> binary_choices,
+                          absl::Span<uint128_t> output, int bit_width_begin,
+                          int num_level) override;
+
   // Random Message Chosen Choice
   void SendRMCC(absl::Span<uint8_t> output0, absl::Span<uint8_t> output1,
                 size_t bit_width = 0) override;


### PR DESCRIPTION
According to the trick from the ABY paper. We can use `k` instances of COTs to compute the B2A. Also the i-th COT only need to transfer `k-i` bits. This on average save about 50% communication of the current B2A implementation which call k instances of COT over k-bit values.

# Pull Request

## What problem does this PR solve?

Issue Number: Fixed #

## Possible side effects?

- Performance:

- Backward compatibility:
