### PR TITLE
Optimizations for Shamir-based Protocol

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // 使用 IntelliSense 了解相关属性。 
+    // 悬停以查看现有属性的描述。
+    // 欲了解更多信息，请访问: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug",
+            "program": "${workspaceFolder}/bazel-bin/libspu/mpc/shamir/protocol_test",
+            "args": ["--gtest_filter=Shamir/ArithmeticTest.A2P/FM32x3"],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/libspu/mpc/ab_api.cc
+++ b/libspu/mpc/ab_api.cc
@@ -118,6 +118,10 @@ Value mul_aa(SPUContext* ctx, const Value& x, const Value& y) {
   TILED_DISPATCH(ctx, x, y);
 }
 
+Value mul_aa_p(SPUContext* ctx, const Value& x, const Value& y) {
+  TILED_DISPATCH(ctx, x, y);
+}
+
 Value square_a(SPUContext* ctx, const Value& x) { TILED_DISPATCH(ctx, x); }
 
 OptionalAPI<Value> mul_av(SPUContext* ctx, const Value& x, const Value& y) {

--- a/libspu/mpc/ab_api.cc
+++ b/libspu/mpc/ab_api.cc
@@ -146,6 +146,10 @@ Value trunc_a(SPUContext* ctx, const Value& x, size_t nbits, SignType sign) {
   TILED_DISPATCH(ctx, x, nbits, sign);
 }
 
+Value mul_aa_trunc(SPUContext *ctx, const Value &x, const Value &y, size_t nbits, SignType sign) {
+  TILED_DISPATCH(ctx, x, y, nbits, sign);
+}
+
 Value mmul_ap(SPUContext* ctx, const Value& x, const Value& y) {
   FORCE_DISPATCH(ctx, x, y);
 }

--- a/libspu/mpc/ab_api.h
+++ b/libspu/mpc/ab_api.h
@@ -41,6 +41,8 @@ OptionalAPI<Value> add_av(SPUContext* ctx, const Value& x, const Value& y);
 
 Value mul_ap(SPUContext* ctx, const Value& x, const Value& y);
 Value mul_aa(SPUContext* ctx, const Value& x, const Value& y);
+Value mul_aa_p(SPUContext* ctx, const Value& x, const Value& y);
+
 Value square_a(SPUContext* ctx, const Value& x);
 OptionalAPI<Value> mul_av(SPUContext* ctx, const Value& x, const Value& y);
 

--- a/libspu/mpc/ab_api.h
+++ b/libspu/mpc/ab_api.h
@@ -51,6 +51,7 @@ OptionalAPI<Value> mul_a1bv(SPUContext* ctx, const Value& x, const Value& y);
 
 Value lshift_a(SPUContext* ctx, const Value& x, const Sizes& nbits);
 Value trunc_a(SPUContext* ctx, const Value& x, size_t nbits, SignType sign);
+Value mul_aa_trunc(SPUContext* ctx, const Value& x, const Value& y, size_t nbits, SignType sign);
 
 Value mmul_ap(SPUContext* ctx, const Value& x, const Value& y);
 Value mmul_aa(SPUContext* ctx, const Value& x, const Value& y);

--- a/libspu/mpc/ab_api_test.cc
+++ b/libspu/mpc/ab_api_test.cc
@@ -303,6 +303,59 @@ TEST_P(ArithmeticTest, MulA1BV) {
   });
 }
 
+TEST_P(ArithmeticTest, MulAA) {
+  const auto factory = std::get<0>(GetParam());
+  const RuntimeConfig& conf = std::get<1>(GetParam());
+  const size_t npc = std::get<2>(GetParam());
+
+  utils::simulate(npc, [&](const std::shared_ptr<yacl::link::Context>& lctx) {
+    auto sctx = factory(conf, lctx);
+
+    auto p0 = rand_p(sctx.get(), kShape);
+    auto p1 = rand_p(sctx.get(), kShape);
+
+    auto v0 = p2v(sctx.get(), p0, 0);
+    auto v1 = p2v(sctx.get(), p1, 1);
+
+    auto a0 = v2a(sctx.get(), v0);
+    auto a1 = v2a(sctx.get(), v1);
+
+    auto prod = mul_aa(sctx.get(), a0, a1);
+    auto p_prod = a2p(sctx.get(), prod);
+
+    auto s = mul_pp(sctx.get(), p0, p1);
+
+    /* THEN */
+    EXPECT_VALUE_EQ(s, p_prod);
+  });
+}
+
+TEST_P(ArithmeticTest, MulAAP) {
+  const auto factory = std::get<0>(GetParam());
+  const RuntimeConfig& conf = std::get<1>(GetParam());
+  const size_t npc = std::get<2>(GetParam());
+
+  utils::simulate(npc, [&](const std::shared_ptr<yacl::link::Context>& lctx) {
+    auto sctx = factory(conf, lctx);
+
+    auto p0 = rand_p(sctx.get(), kShape);
+    auto p1 = rand_p(sctx.get(), kShape);
+
+    auto v0 = p2v(sctx.get(), p0, 0);
+    auto v1 = p2v(sctx.get(), p1, 1);
+
+    auto a0 = v2a(sctx.get(), v0);
+    auto a1 = v2a(sctx.get(), v1);
+
+    auto prod = mul_aa_p(sctx.get(), a0, a1);
+
+    auto s = mul_pp(sctx.get(), p0, p1);
+
+    /* THEN */
+    EXPECT_VALUE_EQ(s, prod);
+  });
+}
+
 TEST_P(ArithmeticTest, MatMulAP) {
   const auto factory = std::get<0>(GetParam());
   const RuntimeConfig& conf = std::get<1>(GetParam());

--- a/libspu/mpc/api_test.cc
+++ b/libspu/mpc/api_test.cc
@@ -25,6 +25,7 @@ namespace spu::mpc::test {
 namespace {
 
 Shape kShape = {20, 30};
+// Shape kShape = {3};
 const std::vector<size_t> kShiftBits = {0, 1, 2, 31, 32, 33, 64, 1000};
 
 #define EXPECT_VALUE_EQ(X, Y)                            \

--- a/libspu/mpc/kernel.cc
+++ b/libspu/mpc/kernel.cc
@@ -107,6 +107,17 @@ void TruncAKernel::evaluate(KernelEvalContext* ctx) const {
   ctx->pushOutput(WrapValue(z));
 }
 
+void MulTruncAKernel::evaluate(KernelEvalContext* ctx) const {
+  const auto& lhs = ctx->getParam<Value>(0);
+  const auto& rhs = ctx->getParam<Value>(1);
+  size_t bits = ctx->getParam<size_t>(2);
+  SignType sign = ctx->getParam<SignType>(3);
+
+  auto z = proc(ctx, UnwrapValue(lhs), UnwrapValue(rhs), bits, sign);
+
+  ctx->pushOutput(WrapValue(z));
+}
+
 void BitSplitKernel::evaluate(KernelEvalContext* ctx) const {
   const auto& in = ctx->getParam<Value>(0);
   size_t stride = ctx->getParam<size_t>(1);

--- a/libspu/mpc/kernel.h
+++ b/libspu/mpc/kernel.h
@@ -106,6 +106,22 @@ class TruncAKernel : public Kernel {
                           size_t bits, SignType sign) const = 0;
 };
 
+class MulTruncAKernel : public Kernel {
+ public:
+  void evaluate(KernelEvalContext* ctx) const override;
+
+  // For protocol like SecureML, the most significant bit may have error with
+  // low probability, which lead to huge calculation error.
+  //
+  // Return true if the protocol has this kind of error.
+  virtual bool hasMsbError() const = 0;
+
+  virtual TruncLsbRounding lsbRounding() const = 0;
+
+  virtual NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& lhs, const NdArrayRef& rhs,
+                          size_t bits, SignType sign) const = 0;
+};
+
 class BitSplitKernel : public Kernel {
  public:
   void evaluate(KernelEvalContext* ctx) const override;

--- a/libspu/mpc/shamir/arithmetic.h
+++ b/libspu/mpc/shamir/arithmetic.h
@@ -168,6 +168,20 @@ class MulAA : public BinaryKernel {
                   const NdArrayRef& rhs) const override;
 };
 
+class MulAAP : public BinaryKernel {
+ public:
+  static constexpr char kBindName[] = "mul_aa_p";
+
+  Kind kind() const override { return Kind::Dynamic; }
+
+  ce::CExpr latency() const override { return ce::Const(1); }
+
+  ce::CExpr comm() const override { return ce::K() * 2 * (ce::N() - 1); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& lhs,
+                  const NdArrayRef& rhs) const override;
+};
+
 ////////////////////////////////////////////////////////////////////
 // matmul family
 ////////////////////////////////////////////////////////////////////

--- a/libspu/mpc/shamir/conversion.cc
+++ b/libspu/mpc/shamir/conversion.cc
@@ -66,13 +66,6 @@ NdArrayRef wrap_mul_p(SPUContext* ctx, const NdArrayRef& x, const NdArrayRef& y)
   return UnwrapValue(mul_aa_p(ctx, WrapValue(x), WrapValue(y)));
 }
 
-void reveal(SPUContext* ctx, const NdArrayRef& x, std::string_view name) {
-  auto x_p = wrap_a2p(ctx, x);
-  if(ctx->getState<Communicator>()->getRank() == 0) {
-    ring_print(x_p, name);
-  }
-}
-
 NdArrayRef wrap_mul(SPUContext* ctx, const NdArrayRef& x, const NdArrayRef& y) {
   if (is_public(x) && is_public(y)) {
     return UnwrapValue(mul_pp(ctx, WrapValue(x), WrapValue(y)));
@@ -815,9 +808,6 @@ NdArrayRef MulAATrunc::proc(KernelEvalContext* ctx, const NdArrayRef& x, const N
           r_2t = wrap_add(sctx, r_2t, wrap_mul(sctx, k, r_bit_square));
     }
     r_2t = wrap_add(sctx, r_2t, zero_shares);
-
-    reveal(sctx, r, "r");
-    reveal(sctx, r_2t, "r_2t");
 
     
     // k2 = 2^(l-2)

--- a/libspu/mpc/shamir/conversion.h
+++ b/libspu/mpc/shamir/conversion.h
@@ -47,17 +47,11 @@ class B2A : public UnaryKernel {
   Kind kind() const override { return Kind::Dynamic; }
 
   ce::CExpr latency() const override {
-    return (Log(ce::K()) + 1) * Log(ce::N())  // A2B
-           + Log(ce::K() + 1)                 // add_bb
-           + 1                                // reveal
-        ;
+    return ce::Const(0);
   }
 
   ce::CExpr comm() const override {
-    const auto n_1 = ce::N() - 1;
-    return (2 * Log(ce::K()) + 1) * 2 * ce::K() * n_1 * n_1  // A2B
-           + (2 * Log(ce::K()) + 1) * 2 * ce::K()            // add_bb
-        ;
+    return ce::Const(0);
   }
 
   NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& x) const override;

--- a/libspu/mpc/shamir/conversion.h
+++ b/libspu/mpc/shamir/conversion.h
@@ -109,7 +109,7 @@ class MsbA : public UnaryKernel {
   ce::CExpr latency() const override {
     // 1 * carry : log(k) + 1
     // 1 * rotate: 1
-    return Log(ce::K()) + 1 + 1;
+    return ce::Const(3);
   }
 
   ce::CExpr comm() const override {

--- a/libspu/mpc/shamir/conversion.h
+++ b/libspu/mpc/shamir/conversion.h
@@ -64,11 +64,32 @@ class TruncA : public TruncAKernel {
 
   Kind kind() const override { return Kind::Dynamic; }
 
-  ce::CExpr latency() const override { return ce::Const(0); }
+  ce::CExpr latency() const override { return ce::Const(1); }
 
   ce::CExpr comm() const override { return ce::Const(0); }
 
   NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& x, size_t bits,
+                  SignType sign) const override;
+
+  bool hasMsbError() const override { return false; }
+
+  // TODO: Add probabilistic truncation (with edabits)
+  TruncLsbRounding lsbRounding() const override {
+    return TruncLsbRounding::Random;
+  }
+};
+
+class MulAATrunc : public MulTruncAKernel {
+ public:
+  static constexpr char kBindName[] = "mul_aa_trunc";
+
+  Kind kind() const override { return Kind::Dynamic; }
+
+  ce::CExpr latency() const override { return ce::Const(1); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& x, const NdArrayRef& y, size_t bits,
                   SignType sign) const override;
 
   bool hasMsbError() const override { return false; }

--- a/libspu/mpc/shamir/io_test.cc
+++ b/libspu/mpc/shamir/io_test.cc
@@ -21,7 +21,7 @@ namespace spu::mpc::shamir {
 INSTANTIATE_TEST_SUITE_P(
     ShamirIoTest, ShamirIoTest,
     testing::Combine(testing::Values(makeShamirIo),  //
-                     testing::Values(3),             //
+                     testing::Values(4),             //
                      testing::Values(FieldType::FM32, FieldType::FM64,
                                      FieldType::FM128)),
     [](const testing::TestParamInfo<ShamirIoTest::ParamType>& p) {

--- a/libspu/mpc/shamir/protocol.cc
+++ b/libspu/mpc/shamir/protocol.cc
@@ -51,7 +51,7 @@ void regShamirProtocol(SPUContext* ctx,
                   shamir::RandA,                       //
                   shamir::NegateA,                     //
                   shamir::AddAP, shamir::AddAA,        //
-                  shamir::MulAP, shamir::MulAA,        //
+                  shamir::MulAP, shamir::MulAA, shamir::MulAAP,       //
                   shamir::MatMulAP, shamir::MatMulAA,  //
                   shamir::LShiftB, shamir::RShiftB, shamir::ARShiftB,
                   shamir::CommonTypeB, shamir::CastTypeB,         //

--- a/libspu/mpc/shamir/protocol.cc
+++ b/libspu/mpc/shamir/protocol.cc
@@ -58,7 +58,7 @@ void regShamirProtocol(SPUContext* ctx,
                   shamir::CommonTypeV, shamir::A2B, shamir::B2A,  //
                   shamir::AndBP, shamir::XorBP,                   //
                   shamir::P2B, shamir::B2P, shamir::B2V, shamir::XorBB,
-                  shamir::AndBB, shamir::BitrevB, shamir::TruncA,
+                  shamir::AndBB, shamir::BitrevB, shamir::TruncA, shamir::MulAATrunc,
                   shamir::MsbA,  //
                   shamir::BitIntlB, shamir::BitDeintlB>();
 }

--- a/libspu/mpc/utils/BUILD.bazel
+++ b/libspu/mpc/utils/BUILD.bazel
@@ -119,6 +119,14 @@ spu_cc_test(
     ],
 )
 
+spu_cc_test(
+    name = "gfmp_ops_test",
+    srcs = ["gfmp_ops_test.cc"],
+    deps = [
+        ":gfmp_ops"
+    ]
+)
+
 spu_cc_binary(
     name = "ring_ops_bench",
     srcs = ["ring_ops_bench.cc"],

--- a/libspu/mpc/utils/gfmp_ops.cc
+++ b/libspu/mpc/utils/gfmp_ops.cc
@@ -65,11 +65,13 @@ void gfmp_inverse_impl(NdArrayRef& ret, const NdArrayRef& x) {
   const auto numel = x.numel();
 
   NdArrayRef prefix_prod(ret.eltype(), ret.shape());
+ 
   DISPATCH_ALL_FIELDS(field, [&]() {
     NdArrayView<ring2k_t> _prefix_prod(prefix_prod);
     NdArrayView<ring2k_t> _x(x);
     NdArrayView<ring2k_t> _ret(ret);
     _prefix_prod[0] = _x[0];
+    // TODO optimize prefix_mult in parallel
     for (int64_t i = 1; i < numel; ++i) {
       _prefix_prod[i] = mul_mod(_prefix_prod[i - 1], _x[i]);
     }

--- a/libspu/mpc/utils/gfmp_ops.cc
+++ b/libspu/mpc/utils/gfmp_ops.cc
@@ -195,11 +195,6 @@ NdArrayRef gfmp_batch_inverse(const NdArrayRef& x) {
   return ret;
 }
 
-void gfmp_batch_inverse(NdArrayRef& x) {
-  SPU_ENFORCE_GFMP(x);
-  gfmp_inverse_impl(x, x);
-}
-
 NdArrayRef gfmp_mul_mod(const NdArrayRef& x, const NdArrayRef& y) {
   SPU_ENFORCE_GFMP(x);
   SPU_ENFORCE_GFMP(y);

--- a/libspu/mpc/utils/gfmp_ops.h
+++ b/libspu/mpc/utils/gfmp_ops.h
@@ -25,6 +25,9 @@ NdArrayRef gfmp_rand(FieldType field, const Shape& shape, uint128_t prg_seed,
 NdArrayRef gfmp_mod(const NdArrayRef& x);
 void gfmp_mod_(NdArrayRef& x);
 
+NdArrayRef gfmp_batch_inverse(const NdArrayRef& x);
+void gfmp_batch_inverse(NdArrayRef& x);
+
 NdArrayRef gfmp_mul_mod(const NdArrayRef& x, const NdArrayRef& y);
 void gfmp_mul_mod_(NdArrayRef& x, const NdArrayRef& y);
 

--- a/libspu/mpc/utils/gfmp_ops.h
+++ b/libspu/mpc/utils/gfmp_ops.h
@@ -26,7 +26,6 @@ NdArrayRef gfmp_mod(const NdArrayRef& x);
 void gfmp_mod_(NdArrayRef& x);
 
 NdArrayRef gfmp_batch_inverse(const NdArrayRef& x);
-void gfmp_batch_inverse(NdArrayRef& x);
 
 NdArrayRef gfmp_mul_mod(const NdArrayRef& x, const NdArrayRef& y);
 void gfmp_mul_mod_(NdArrayRef& x, const NdArrayRef& y);

--- a/libspu/mpc/utils/gfmp_ops_test.cc
+++ b/libspu/mpc/utils/gfmp_ops_test.cc
@@ -1,0 +1,79 @@
+// Copyright 2021 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "libspu/mpc/utils/gfmp_ops.h"
+#include "libspu/mpc/utils/ring_ops.h"
+
+#include <random>
+
+#include "gtest/gtest.h"
+
+namespace spu::mpc {
+
+class GfmpArrayRefTest
+    : public ::testing::TestWithParam<
+            std::tuple<FieldType,
+                        int64_t,
+                        int64_t>> {};
+
+static NdArrayRef makeRandomArray(FieldType field, int64_t numel,
+                                    int64_t stride) {
+    const Type ty = makeType<GfmpTy>(field);
+    const size_t buf_size = SizeOf(field) * numel * stride;
+
+    auto buf = std::make_shared<yacl::Buffer>(buf_size);
+    {
+        size_t numOfInts = buf_size / sizeof(int32_t);
+        auto* begin = buf->data<int32_t>();
+        for(size_t idx = 0; idx < numOfInts; idx++) {
+            *(begin + idx) = std::rand();
+        }
+    }
+    return gfmp_mod(NdArrayRef(buf, ty, {numel}, {stride}, 0));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    GfmpArrayRefTestSuite, GfmpArrayRefTest,
+    testing::Combine(testing::Values(FM32, FM64, FM128),  //
+                     testing::Values(1, 3, 10000),         // size of parameters
+                     testing::Values(1, 3)  // stride of first param
+                     ),
+    [](const testing::TestParamInfo<GfmpArrayRefTest::ParamType>& p) {
+      return fmt::format("{}x{}x{}", std::get<0>(p.param),
+                         std::get<1>(p.param), std::get<2>(p.param));
+    });
+
+TEST_P(GfmpArrayRefTest, BatchInverse) {
+  const FieldType field = std::get<0>(GetParam());
+  const int64_t numel = std::get<1>(GetParam());
+  const int64_t stride = std::get<2>(GetParam());
+  const Type ty = makeType<RingTy>(field);
+
+  // GIVEN
+  const NdArrayRef y = makeRandomArray(field, numel, stride);
+  DISPATCH_ALL_FIELDS(field, [&]() {
+    NdArrayView<ring2k_t> _y(y);
+    pforeach(0, numel, [&](int64_t idx) {_y[idx]=idx+1;});
+  });
+
+  NdArrayRef x = gfmp_batch_inverse(y);
+  NdArrayRef ones = ring_ones(field, y.shape());
+  // WHEN
+  NdArrayRef z = gfmp_mul_mod(x, y);  // x = y;
+
+  // THEN
+  EXPECT_TRUE(ring_all_equal(z, ones));
+}
+
+}

--- a/refresh-compile-commands.py
+++ b/refresh-compile-commands.py
@@ -1,0 +1,155 @@
+#! /usr/bin/env python3
+
+# Copyright 2023 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import pathlib
+import shutil
+import argparse
+import subprocess
+
+workspace_file_content = """
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+git_repository(
+    name = "hedron_compile_commands",
+    commit = "388cc00156cbf53570c416d39875b15f03c0b47f",
+    remote = "https://github.com/hedronvision/bazel-compile-commands-extractor.git",
+)
+
+load("@hedron_compile_commands//:workspace_setup.bzl", "hedron_compile_commands_setup")
+
+hedron_compile_commands_setup()
+"""
+
+def _build_file_content(content, targets):
+    return f"""
+load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile_commands")
+
+{content}
+
+refresh_compile_commands(
+    name = "refresh_compile_commands",
+    exclude_external_sources = True,
+    exclude_headers = "external",
+    {targets}
+)
+
+"""
+
+def _run_shell_command_with_live_output(cmd, cwd, shell=True):
+    print(cmd)
+    p = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=cwd, shell=shell
+    )
+    for line in p.stdout:
+        print(line.decode("utf-8").rstrip())
+    p.wait()
+    status = p.poll()
+    assert status == 0
+
+def _rm(path: str):
+    p = pathlib.Path(path)
+    if os.path.isfile:
+        p.unlink()
+    else:
+        p.rmdir()
+
+
+def _backup_file(path: str):
+    shutil.copy(src=path, dst=f"{path}_bak")
+
+
+def _restore_file(path: str):
+    backup = f"{path}_bak"
+    shutil.copy(src=backup, dst=path)
+    _rm(backup)
+
+
+class Workspace(object):
+    def __init__(self):
+        self.workspace_file = 'WORKSPACE'
+
+        if os.path.isfile('BUILD.bazel'):
+            self.build_file = 'BUILD.bazel'
+        else:
+            self.build_file = 'BUILD'
+
+        self.has_build = os.path.exists(self.build_file)
+
+    def __enter__(self):
+        if self.has_build:
+            _backup_file(self.build_file)
+        else:
+            # Create empty file
+            with open(self.build_file, 'w') as fp:
+                pass
+
+        _backup_file(self.workspace_file)
+        return self
+
+    def __exit__(self, *args):
+        # Restore files
+        _restore_file(self.workspace_file)
+
+        if self.has_build:
+            _restore_file(self.build_file)
+        else:
+            _rm(self.build_file)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="(Re)generate compile commands for Bazel project"
+    )
+
+    parser.add_argument(
+        "--targets",
+        metavar="bazel targets",
+        type=str,
+        help="bazel build targets, comma separated",
+    )
+
+    args = parser.parse_args()
+
+    with Workspace() as ws:
+        # Add hedron_compile_commands to workspace
+        with open(ws.workspace_file, "a+") as wf:
+            wf.write(workspace_file_content)
+
+        # Build targets
+        targets = args.targets
+        t_str = ""
+        if targets:
+            for t in targets.split(','):
+                t_str += f'       "{t}": "",\n'
+
+        if t_str:
+            t_str = f"targets = {{\n{t_str}    }}"
+
+        # Add build rule
+        with open(ws.build_file, "r+") as bf:
+            content = bf.read()
+            bf.seek(0)
+
+            # append load at beginning
+            content = _build_file_content(content, targets=t_str)
+            bf.write(content)
+
+        # Run
+        _run_shell_command_with_live_output(
+            'bazel run -s :refresh_compile_commands', cwd=os.getcwd(), shell=True
+        )
+


### PR DESCRIPTION
# Pull Request

## What problem does this PR solve?

主要修改包括：
libspu/mpc/utils/gfmp_ops.cc
*        修改gfmp_reconstruct_shamir_shares中的公式
*        增加batch_inversion操作，以及相应的gtest
‎libspu/mpc/shamir/arithmetic.cc
*        增加MulAAP接口（即合并MulAA + A2P运算），以及相应的gtest；
*        增加PRZS（随机零分享）接口；
*        修改P2A协议：random shamir sharing -> public values as sharing；
libspu/mpc/shamir/boolean.cc
*        修改B2P协议：-> B2A + A2P
*        修改B2V协议：-> B2A + A2V
libspu/mpc/shamir/conversion.cc
*        用batch_inversion优化rand_bits
*        利用梅森素数的性质优化rand_bits协议
*        删除rand_bits_pair协议
*        利用梅森素数的性质优化solved_bits
*        新增gen_prefix_mul_share接口，生成用于计算prefix_mult所需的random pairs
*        利用gen_prefix_mul重新实现prefix_mul协议，测试MsbA接口
*        利用重新实现的prefix_mul接口优化bit_it_ap协议
*        优化unbounded_carries协议
*        优化A2B协议
*        新增MultAATrunc协议，即定点小数乘法协议

Issue Number: Fixed #

## Possible side effects?

- Performance:

- Backward compatibility:
