### PR TITLE
Add Shamir-based Protocol

### DIFF
--- a/src/libspu/core/config.cc
+++ b/src/libspu/core/config.cc
@@ -115,6 +115,11 @@ void populateRuntimeConfig(RuntimeConfig& cfg) {
     cfg.set_sigmoid_mode(RuntimeConfig::SIGMOID_REAL);
   }
 
+  // shamir threshold
+  if (cfg.protocol() == ProtocolKind::SHAMIR && cfg.sss_threshold() == 0) {
+    SPU_THROW("shamir secret sharing threshold must be set");
+  }
+
   // MPC related configurations
   // trunc_allow_msb_error           // by pass.
 }

--- a/src/libspu/core/encoding.cc
+++ b/src/libspu/core/encoding.cc
@@ -168,4 +168,140 @@ void decodeFromRing(const NdArrayRef& src, DataType in_dtype, size_t fxp_bits,
   });
 }
 
+NdArrayRef encodeToGfmp(const PtBufferView& bv, FieldType field,
+                        size_t fxp_bits, DataType* out_dtype) {
+  const PtType pt_type = bv.pt_type;
+  const size_t numel = bv.shape.numel();
+  NdArrayRef dst(makeType<GfmpTy>(field), bv.shape);
+  const auto* dst_ty = dst.eltype().as<GfmpTy>();
+
+  if (out_dtype != nullptr) {
+    *out_dtype = getEncodeType(pt_type);
+  }
+
+  if (pt_type == PT_F32 || pt_type == PT_F64 || pt_type == PT_F16) {
+    DISPATCH_FLOAT_PT_TYPES(pt_type, [&]() {
+      DISPATCH_ALL_FIELDS(field, [&]() {
+        using Float = ScalarT;
+
+        using U = ring2k_t;
+        using S = std::make_signed_t<ring2k_t>;
+        const auto p = static_cast<U>(dst_ty->p());
+        const S max_positve = p >> 1;
+        auto min_negetive = -max_positve;
+
+        // We have a Mersenne prime like p = 2^k -1, then encode integer in
+        // range [-2^(k-1)-1,2^(k-1)-1] to [0, 2^k -2]
+
+        const S kScale = S(1) << fxp_bits;
+        const auto kFlpUpper =
+            static_cast<Float>(static_cast<double>(max_positve) / kScale);
+        const auto kFlpLower =
+            static_cast<Float>(static_cast<double>(min_negetive) / kScale);
+
+        auto _dst = NdArrayView<S>(dst);
+
+        pforeach(0, numel, [&](int64_t idx) {
+          auto src_value = bv.get<Float>(idx);
+          S dst_val;
+          if (std::isnan(src_value)) {
+            // see numpy.nan_to_num
+            // note(jint) I dont know why nan could be
+            // encoded as zero..
+            dst_val = 0;
+          } else if (src_value >= kFlpUpper) {
+            dst_val = max_positve;
+          } else if (src_value <= kFlpLower) {
+            dst_val = min_negetive;
+          } else {
+            dst_val = src_value * kScale;
+          }
+          dst_val = dst_val >= 0 ? dst_val : dst_val + p;
+          _dst[idx] = static_cast<U>(dst_val);
+        });
+      });
+    });
+
+    return dst;
+  } else {
+    // handle integer & boolean
+    DISPATCH_INT_PT_TYPES(pt_type, [&]() {
+      DISPATCH_ALL_FIELDS(field, [&]() {
+        using Integer = ScalarT;
+        SPU_ENFORCE(sizeof(ring2k_t) >= sizeof(Integer),
+                    "integer encoding failed, ring={} could not represent {}",
+                    field, pt_type);
+        using U = ring2k_t;
+        using S = std::make_signed_t<ring2k_t>;
+        const auto p = static_cast<U>(dst_ty->p());
+        const S max_positve = p >> 1;
+        auto min_negetive = -max_positve;
+
+        // We have a Mersenne prime like p = 2^k -1, then encode integer in
+        // range [-2^(k-1)-1, 2^(k-1)-1] to [0, 2^k - 2]
+
+        auto _dst = NdArrayView<U>(dst);
+        pforeach(0, numel, [&](int64_t idx) {
+          // the cast is safe for all valid inputs
+          auto src_value = static_cast<S>(bv.get<Integer>(idx));
+          src_value = std::clamp<S>(src_value, min_negetive, max_positve);
+          src_value = src_value >= 0 ? src_value : src_value + p;
+          _dst[idx] = static_cast<U>(src_value);
+        });
+      });
+    });
+
+    return dst;
+  }
+
+  SPU_THROW("should not be here");
+}
+
+void decodeFromGfmp(const NdArrayRef& src, DataType in_dtype, size_t fxp_bits,
+                    PtBufferView* out_bv, PtType* out_pt_type) {
+  const Type& src_type = src.eltype();
+  SPU_ENFORCE(src_type.isa<GfmpTy>(), "should be gfmp type but got={}",
+              src_type);
+  const FieldType field = src_type.as<Ring2k>()->field();
+  const PtType pt_type = getDecodeType(in_dtype);
+  const size_t numel = src.numel();
+
+  if (out_pt_type != nullptr) {
+    *out_pt_type = pt_type;
+  }
+
+  DISPATCH_ALL_FIELDS(field, [&]() {
+    DISPATCH_ALL_PT_TYPES(pt_type, [&]() {
+      using U = ring2k_t;
+      using S = std::make_signed_t<ring2k_t>;
+      const auto p = static_cast<U>(src_type.as<GfmpTy>()->p());
+      const auto max_positve = p >> 1;
+
+      auto _src = NdArrayView<U>(src);
+
+      if (in_dtype == DT_I1) {
+        pforeach(0, numel, [&](int64_t idx) {
+          bool value = !((_src[idx] & 0x1) == 0);
+          out_bv->set<bool>(idx, value);
+        });
+      } else if (in_dtype == DT_F32 || in_dtype == DT_F64 ||
+                 in_dtype == DT_F16) {
+        const S kScale = S(1) << fxp_bits;
+        pforeach(0, numel, [&](int64_t idx) {
+          S dst_val = _src[idx] > max_positve ? _src[idx] - p : _src[idx];
+          auto value =
+              static_cast<ScalarT>(static_cast<double>(dst_val) / kScale);
+          out_bv->set<ScalarT>(idx, value);
+        });
+      } else {
+        pforeach(0, numel, [&](int64_t idx) {
+          S dst_val = _src[idx] > max_positve ? _src[idx] - p : _src[idx];
+          auto value = static_cast<ScalarT>(dst_val);
+          out_bv->set<ScalarT>(idx, value);
+        });
+      }
+    });
+  });
+}
+
 }  // namespace spu

--- a/src/libspu/core/encoding.h
+++ b/src/libspu/core/encoding.h
@@ -90,4 +90,10 @@ NdArrayRef encodeToRing(const PtBufferView& src, FieldType field,
 void decodeFromRing(const NdArrayRef& src, DataType in_dtype, size_t fxp_bits,
                     PtBufferView* out_bv, PtType* out_pt_type = nullptr);
 
+NdArrayRef encodeToGfmp(const PtBufferView& src, FieldType field,
+                        size_t fxp_bits, DataType* out_dtype = nullptr);
+
+void decodeFromGfmp(const NdArrayRef& src, DataType in_dtype, size_t fxp_bits,
+                    PtBufferView* out_bv, PtType* out_pt_type = nullptr);
+
 }  // namespace spu

--- a/src/libspu/kernel/hal/polymorphic.cc
+++ b/src/libspu/kernel/hal/polymorphic.cc
@@ -266,8 +266,12 @@ Value bitwise_or(SPUContext* ctx, const Value& x, const Value& y) {
 
 Value bitwise_not(SPUContext* ctx, const Value& in) {
   SPU_TRACE_HAL_DISP(ctx, in);
-
-  return _not(ctx, in).setDtype(in.dtype());
+  if (ctx->config().protocol() == ProtocolKind::SHAMIR) {
+    // Fixme: we use Mersenne prime here, bitwise_not zero is not right
+    return _negate(ctx, in).setDtype(in.dtype());
+  } else {
+    return _not(ctx, in).setDtype(in.dtype());
+  }
 }
 
 Value logistic(SPUContext* ctx, const Value& in) {

--- a/src/libspu/mpc/BUILD.bazel
+++ b/src/libspu/mpc/BUILD.bazel
@@ -41,6 +41,21 @@ spu_cc_library(
 )
 
 spu_cc_library(
+    name = "io_shamir_test",
+    testonly = 1,
+    srcs = ["io_shamir_test.cc"],
+    hdrs = ["io_shamir_test.h"],
+    deps = [
+        ":io_interface",
+        "//libspu/mpc/utils:gfmp_ops",
+        "//libspu/mpc/utils:ring_ops",
+        "//libspu/mpc/utils:simulate",
+        "@googletest//:gtest",
+    ],
+    alwayslink = True,
+)
+
+spu_cc_library(
     name = "factory",
     srcs = ["factory.cc"],
     hdrs = ["factory.h"],

--- a/src/libspu/mpc/ab_api.cc
+++ b/src/libspu/mpc/ab_api.cc
@@ -77,6 +77,7 @@ Value v2a(SPUContext* ctx, const Value& x) {
 }
 
 Value msb_a2b(SPUContext* ctx, const Value& x) { TILED_DISPATCH(ctx, x); }
+Value msb_a(SPUContext* ctx, const Value& x) { TILED_DISPATCH(ctx, x); }
 
 Value rand_a(SPUContext* ctx, const Shape& shape) {
   FORCE_DISPATCH(ctx, shape);
@@ -117,6 +118,14 @@ Value mul_aa(SPUContext* ctx, const Value& x, const Value& y) {
   TILED_DISPATCH(ctx, x, y);
 }
 
+Value mul_aaa(SPUContext* ctx, const Value& x, const Value& y, const Value& z) {
+  TILED_DISPATCH(ctx, x, y, z);
+}
+
+Value mul_aa_p(SPUContext* ctx, const Value& x, const Value& y) {
+  TILED_DISPATCH(ctx, x, y);
+}
+
 Value square_a(SPUContext* ctx, const Value& x) { TILED_DISPATCH(ctx, x); }
 
 OptionalAPI<Value> mul_av(SPUContext* ctx, const Value& x, const Value& y) {
@@ -139,6 +148,11 @@ Value lshift_a(SPUContext* ctx, const Value& x, const Sizes& nbits) {
 
 Value trunc_a(SPUContext* ctx, const Value& x, size_t nbits, SignType sign) {
   TILED_DISPATCH(ctx, x, nbits, sign);
+}
+
+Value mul_aa_trunc(SPUContext* ctx, const Value& x, const Value& y,
+                   size_t nbits, SignType sign) {
+  TILED_DISPATCH(ctx, x, y, nbits, sign);
 }
 
 Value mmul_ap(SPUContext* ctx, const Value& x, const Value& y) {

--- a/src/libspu/mpc/ab_api.h
+++ b/src/libspu/mpc/ab_api.h
@@ -25,6 +25,7 @@ Value a2v(SPUContext* ctx, const Value& x, size_t owner);
 Value v2a(SPUContext* ctx, const Value& x);
 
 Value msb_a2b(SPUContext* ctx, const Value& x);
+Value msb_a(SPUContext* ctx, const Value& x);
 
 Value rand_a(SPUContext* ctx, const Shape& shape);
 Value rand_b(SPUContext* ctx, const Shape& shape);
@@ -40,6 +41,9 @@ OptionalAPI<Value> add_av(SPUContext* ctx, const Value& x, const Value& y);
 
 Value mul_ap(SPUContext* ctx, const Value& x, const Value& y);
 Value mul_aa(SPUContext* ctx, const Value& x, const Value& y);
+Value mul_aaa(SPUContext* ctx, const Value& x, const Value& y, const Value& z);
+Value mul_aa_p(SPUContext* ctx, const Value& x, const Value& y);
+
 Value square_a(SPUContext* ctx, const Value& x);
 OptionalAPI<Value> mul_av(SPUContext* ctx, const Value& x, const Value& y);
 
@@ -48,6 +52,8 @@ OptionalAPI<Value> mul_a1bv(SPUContext* ctx, const Value& x, const Value& y);
 
 Value lshift_a(SPUContext* ctx, const Value& x, const Sizes& nbits);
 Value trunc_a(SPUContext* ctx, const Value& x, size_t nbits, SignType sign);
+Value mul_aa_trunc(SPUContext* ctx, const Value& x, const Value& y,
+                   size_t nbits, SignType sign);
 
 Value mmul_ap(SPUContext* ctx, const Value& x, const Value& y);
 Value mmul_aa(SPUContext* ctx, const Value& x, const Value& y);

--- a/src/libspu/mpc/ab_api_test.cc
+++ b/src/libspu/mpc/ab_api_test.cc
@@ -81,7 +81,6 @@ bool verifyCost(Kernel* kernel, std::string_view name, FieldType field,
   ce::Params params = {{"K", SizeOf(field) * 8}, {"N", npc}};
   return verifyCost(kernel, name, params, cost, shape.numel() /*repeated*/);
 }
-
 }  // namespace
 
 #define TEST_ARITHMETIC_BINARY_OP_AA(OP)                                       \
@@ -304,6 +303,90 @@ TEST_P(ArithmeticTest, MulA1BV) {
   });
 }
 
+TEST_P(ArithmeticTest, MulAA) {
+  const auto factory = std::get<0>(GetParam());
+  const RuntimeConfig& conf = std::get<1>(GetParam());
+  const size_t npc = std::get<2>(GetParam());
+
+  utils::simulate(npc, [&](const std::shared_ptr<yacl::link::Context>& lctx) {
+    auto sctx = factory(conf, lctx);
+
+    auto p0 = rand_p(sctx.get(), kShape);
+    auto p1 = rand_p(sctx.get(), kShape);
+
+    auto v0 = p2v(sctx.get(), p0, 0);
+    auto v1 = p2v(sctx.get(), p1, 1);
+
+    auto a0 = v2a(sctx.get(), v0);
+    auto a1 = v2a(sctx.get(), v1);
+
+    auto prod = mul_aa(sctx.get(), a0, a1);
+    auto p_prod = a2p(sctx.get(), prod);
+
+    auto s = mul_pp(sctx.get(), p0, p1);
+
+    /* THEN */
+    EXPECT_VALUE_EQ(s, p_prod);
+  });
+}
+
+TEST_P(ArithmeticTest, MulAAA) {
+  const auto factory = std::get<0>(GetParam());
+  const RuntimeConfig& conf = std::get<1>(GetParam());
+  const size_t npc = std::get<2>(GetParam());
+
+  utils::simulate(npc, [&](const std::shared_ptr<yacl::link::Context>& lctx) {
+    auto sctx = factory(conf, lctx);
+
+    auto p0 = rand_p(sctx.get(), kShape);
+    auto p1 = rand_p(sctx.get(), kShape);
+    auto p2 = rand_p(sctx.get(), kShape);
+
+    auto v0 = p2v(sctx.get(), p0, 0);
+    auto v1 = p2v(sctx.get(), p1, 1);
+    auto v2 = p2v(sctx.get(), p2, 2);
+
+    auto a0 = v2a(sctx.get(), v0);
+    auto a1 = v2a(sctx.get(), v1);
+    auto a2 = v2a(sctx.get(), v2);
+
+    auto prod = mul_aaa(sctx.get(), a0, a1, a2);
+    auto p_prod = a2p(sctx.get(), prod);
+
+    auto s = mul_pp(sctx.get(), p0, p1);
+    auto s_prime = mul_pp(sctx.get(), s, p2);
+
+    /* THEN */
+    EXPECT_VALUE_EQ(s_prime, p_prod);
+  });
+}
+
+TEST_P(ArithmeticTest, MulAAP) {
+  const auto factory = std::get<0>(GetParam());
+  const RuntimeConfig& conf = std::get<1>(GetParam());
+  const size_t npc = std::get<2>(GetParam());
+
+  utils::simulate(npc, [&](const std::shared_ptr<yacl::link::Context>& lctx) {
+    auto sctx = factory(conf, lctx);
+
+    auto p0 = rand_p(sctx.get(), kShape);
+    auto p1 = rand_p(sctx.get(), kShape);
+
+    auto v0 = p2v(sctx.get(), p0, 0);
+    auto v1 = p2v(sctx.get(), p1, 1);
+
+    auto a0 = v2a(sctx.get(), v0);
+    auto a1 = v2a(sctx.get(), v1);
+
+    auto prod = mul_aa_p(sctx.get(), a0, a1);
+
+    auto s = mul_pp(sctx.get(), p0, p1);
+
+    /* THEN */
+    EXPECT_VALUE_EQ(s, prod);
+  });
+}
+
 TEST_P(ArithmeticTest, MatMulAP) {
   const auto factory = std::get<0>(GetParam());
   const RuntimeConfig& conf = std::get<1>(GetParam());
@@ -471,7 +554,9 @@ TEST_P(ArithmeticTest, LShiftA) {
 
   utils::simulate(npc, [&](const std::shared_ptr<yacl::link::Context>& lctx) {
     auto obj = factory(conf, lctx);
-
+    if (!obj->prot()->hasKernel("lshift_a")) {
+      return;
+    }
     /* GIVEN */
     auto p0 = rand_p(obj.get(), kShape);
     auto a0 = p2a(obj.get(), p0);
@@ -520,10 +605,12 @@ TEST_P(ArithmeticTest, TruncA) {
       p0 = arshift_p(obj.get(), p0,
                      {static_cast<int64_t>(SizeOf(conf.field()) * 8 - 10)});
     }
+    auto v0 = p2v(obj.get(), p0, 0);
 
     /* GIVEN */
     const size_t bits = 2;
-    auto a0 = p2a(obj.get(), p0);
+    auto a0 = v2a(obj.get(), v0);
+    // auto a0 = p2a(obj.get(), p0);
 
     /* WHEN */
     auto prev = obj->prot()->getState<Communicator>()->getStats();
@@ -537,6 +624,49 @@ TEST_P(ArithmeticTest, TruncA) {
     EXPECT_VALUE_ALMOST_EQ(r_a, r_p, npc);
     EXPECT_TRUE(verifyCost(obj->prot()->getKernel("trunc_a"), "trunc_a",
                            conf.field(), kShape, npc, cost));
+  });
+}
+
+TEST_P(ArithmeticTest, MulAATrunc) {
+  const auto factory = std::get<0>(GetParam());
+  const RuntimeConfig& conf = std::get<1>(GetParam());
+  const size_t npc = std::get<2>(GetParam());
+
+  // ArrayRef p0_large =
+  //     ring_rand_range(conf.field(), kShape, -(1 << 28), -(1 << 27));
+  // ArrayRef p0_small = ring_rand_range(conf.field(), kShape, 1, 10000);
+
+  utils::simulate(npc, [&](const std::shared_ptr<yacl::link::Context>& lctx) {
+    auto obj = factory(conf, lctx);
+
+    auto p0 = rand_p(obj.get(), kShape);
+    auto p1 = rand_p(obj.get(), kShape);
+
+    auto bits_range_gap = p0.elsize() * 8 - (p0.elsize() * 8) / 2;
+    p0 = arshift_p(obj.get(), p0, {static_cast<int64_t>(bits_range_gap)});
+    p1 = arshift_p(obj.get(), p1, {static_cast<int64_t>(bits_range_gap)});
+    auto prod = mul_pp(obj.get(), p0, p1);
+
+    auto v0 = p2v(obj.get(), p0, 0);
+    auto v1 = p2v(obj.get(), p1, 1);
+
+    /* GIVEN */
+    auto a0 = v2a(obj.get(), v0);
+    auto a1 = v2a(obj.get(), v1);
+
+    /* WHEN */
+    const size_t bits = 2;
+    auto prev = obj->prot()->getState<Communicator>()->getStats();
+    auto prod_a = mul_aa_trunc(obj.get(), a0, a1, bits, SignType::Unknown);
+    auto cost = obj->prot()->getState<Communicator>()->getStats() - prev;
+
+    auto r_a = a2p(obj.get(), prod_a);
+    auto r_p = arshift_p(obj.get(), prod, {static_cast<int64_t>(bits)});
+
+    /* THEN */
+    EXPECT_VALUE_ALMOST_EQ(r_a, r_p, npc);
+    EXPECT_TRUE(verifyCost(obj->prot()->getKernel("mul_aa_trunc"),
+                           "mul_aa_trunc", conf.field(), kShape, npc, cost));
   });
 }
 
@@ -588,35 +718,45 @@ TEST_P(ArithmeticTest, A2P) {
   });
 }
 
-#define TEST_BOOLEAN_BINARY_OP_BB(OP)                                          \
-  TEST_P(BooleanTest, OP##BB) {                                                \
-    const auto factory = std::get<0>(GetParam());                              \
-    const RuntimeConfig& conf = std::get<1>(GetParam());                       \
-    const size_t npc = std::get<2>(GetParam());                                \
-                                                                               \
-    utils::simulate(                                                           \
-        npc, [&](const std::shared_ptr<yacl::link::Context>& lctx) {           \
-          auto obj = factory(conf, lctx);                                      \
-                                                                               \
-          /* GIVEN */                                                          \
-          auto p0 = rand_p(obj.get(), kShape);                                 \
-          auto p1 = rand_p(obj.get(), kShape);                                 \
-                                                                               \
-          /* WHEN */                                                           \
-          auto b0 = p2b(obj.get(), p0);                                        \
-          auto b1 = p2b(obj.get(), p1);                                        \
-          auto prev = obj->prot()->getState<Communicator>()->getStats();       \
-          auto tmp = OP##_bb(obj.get(), b0, b1);                               \
-          auto cost =                                                          \
-              obj->prot()->getState<Communicator>()->getStats() - prev;        \
-          auto re = b2p(obj.get(), tmp);                                       \
-          auto rp = OP##_pp(obj.get(), p0, p1);                                \
-                                                                               \
-          /* THEN */                                                           \
-          EXPECT_VALUE_EQ(re, rp);                                             \
-          EXPECT_TRUE(verifyCost(obj->prot()->getKernel(#OP "_bb"), #OP "_bb", \
-                                 conf.field(), kShape, npc, cost));            \
-        });                                                                    \
+#define TEST_BOOLEAN_BINARY_OP_BB(OP)                                         \
+  TEST_P(BooleanTest, OP##BB) {                                               \
+    const auto factory = std::get<0>(GetParam());                             \
+    const RuntimeConfig& conf = std::get<1>(GetParam());                      \
+    const size_t npc = std::get<2>(GetParam());                               \
+                                                                              \
+    utils::simulate(                                                          \
+        npc, [&](const std::shared_ptr<yacl::link::Context>& lctx) {          \
+          auto obj = factory(conf, lctx);                                     \
+                                                                              \
+          /* GIVEN */                                                         \
+          auto p0 = rand_p(obj.get(), kShape);                                \
+          auto p1 = rand_p(obj.get(), kShape);                                \
+                                                                              \
+          /* WHEN */                                                          \
+          auto b0 = p2b(obj.get(), p0);                                       \
+          auto b1 = p2b(obj.get(), p1);                                       \
+          auto prev = obj->prot()->getState<Communicator>()->getStats();      \
+          auto tmp = OP##_bb(obj.get(), b0, b1);                              \
+          auto cost =                                                         \
+              obj->prot()->getState<Communicator>()->getStats() - prev;       \
+          auto re = b2p(obj.get(), tmp);                                      \
+          auto rp = OP##_pp(obj.get(), p0, p1);                               \
+                                                                              \
+          /* THEN */                                                          \
+          EXPECT_VALUE_EQ(re, rp);                                            \
+          if (conf.protocol() == ProtocolKind::SHAMIR) {                      \
+            const size_t nBits = GetMersennePrimeExp(conf.field());           \
+            ce::Params params = {{"K", SizeOf(conf.field()) * 8},             \
+                                 {"N", npc},                                  \
+                                 {"nBits", nBits}};                           \
+            EXPECT_TRUE(verifyCost(obj->prot()->getKernel(#OP "_bb"),         \
+                                   #OP "_aa", params, cost, kShape.numel())); \
+          } else {                                                            \
+            EXPECT_TRUE(verifyCost(obj->prot()->getKernel(#OP "_bb"),         \
+                                   #OP "_aa", conf.field(), kShape, npc,      \
+                                   cost));                                    \
+          }                                                                   \
+        });                                                                   \
   }
 
 #define TEST_BOOLEAN_BINARY_OP_BP(OP)                                          \
@@ -671,6 +811,10 @@ TEST_BOOLEAN_BINARY_OP(xor)
           auto b0 = p2b(obj.get(), p0);                                        \
                                                                                \
           for (auto bits : kShiftBits) {                                       \
+            if (conf.protocol() == ProtocolKind::SHAMIR &&                     \
+                bits >= GetMersennePrimeExp(conf.field())) {                   \
+              continue;                                                        \
+            }                                                                  \
             if (bits >= p0.elsize() * 8) {                                     \
               continue;                                                        \
             }                                                                  \

--- a/src/libspu/mpc/api.cc
+++ b/src/libspu/mpc/api.cc
@@ -334,6 +334,8 @@ Value msb_s(SPUContext* ctx, const Value& x) {
       // fast path, directly apply msb x AShare, result a BShare.
       return msb_a2b(ctx, x);
     }
+  } else if (ctx->hasKernel("msb_a") && IsA(x)) {
+    return msb_a(ctx, x);
   } else {
     return rshift_b(ctx, _2b(ctx, x),
                     {static_cast<int64_t>(SizeOf(field) * 8 - 1)});
@@ -343,6 +345,8 @@ Value msb_s(SPUContext* ctx, const Value& x) {
 Value msb_v(SPUContext* ctx, const Value& x) { FORCE_DISPATCH(ctx, x); }
 
 Value msb_p(SPUContext* ctx, const Value& x) { FORCE_DISPATCH(ctx, x); }
+
+Value relu(SPUContext* ctx, const Value& x) {FORCE_DISPATCH(ctx, x); }
 
 //////////////////////////////////////////////////////////////////////////////
 
@@ -631,12 +635,10 @@ Value xor_pp(SPUContext* ctx, const Value& x, const Value& y) {
 Value lshift_s(SPUContext* ctx, const Value& x, const Sizes& bits) {
   SPU_TRACE_MPC_DISP(ctx, x, bits);
   TRY_DISPATCH(ctx, x, bits);
-  if (IsA(x)) {
+  if (IsA(x) && ctx->hasKernel("lshift_a")) {
     return lshift_a(ctx, x, bits);
-  } else if (IsB(x)) {
-    return lshift_b(ctx, x, bits);
   } else {
-    SPU_THROW("Unsupported type {}", x.storage_type());
+    return lshift_b(ctx, _2b(ctx, x), bits);
   }
 }
 

--- a/src/libspu/mpc/api.h
+++ b/src/libspu/mpc/api.h
@@ -105,6 +105,8 @@ Value msb_p(SPUContext* ctx, const Value& x);
 Value msb_s(SPUContext* ctx, const Value& x);
 Value msb_v(SPUContext* ctx, const Value& x);
 
+Value relu(SPUContext* ctx, const Value& x);
+
 Value equal_pp(SPUContext* ctx, const Value& x, const Value& y);
 OptionalAPI<Value> equal_sp(SPUContext* ctx, const Value& x, const Value& y);
 OptionalAPI<Value> equal_ss(SPUContext* ctx, const Value& x, const Value& y);

--- a/src/libspu/mpc/api_test.cc
+++ b/src/libspu/mpc/api_test.cc
@@ -246,7 +246,7 @@ TEST_BINARY_OP(xor)
   TEST_UNARY_OP_P(OP)
 
 TEST_UNARY_OP(negate)
-TEST_UNARY_OP(not )
+TEST_UNARY_OP(not)
 TEST_UNARY_OP_V(msb)
 TEST_UNARY_OP_P(msb)
 
@@ -273,6 +273,32 @@ TEST_P(ApiTest, MsbS) {
   });
 }
 
+TEST_P(ApiTest, ReLU) {
+  const auto factory = std::get<0>(GetParam());
+  const RuntimeConfig& conf = std::get<1>(GetParam());
+  const size_t npc = std::get<2>(GetParam());
+
+  utils::simulate(npc, [&](const std::shared_ptr<yacl::link::Context>& lctx) {
+    auto sctx = factory(conf, lctx);
+
+    auto p0 = rand_p(sctx.get(), kShape);
+
+    // SECURENN has an msb input range requirement here
+    if (conf.protocol() == ProtocolKind::SECURENN) {
+      p0 = arshift_p(sctx.get(), p0, {1});
+    }
+
+    auto relu_s = relu(sctx.get(), p2s(sctx.get(), p0));
+    
+    auto r_p = msb_p(sctx.get(), p0);
+    auto d_relu = add_pp(sctx.get(), make_p(sctx.get(), 1, kShape), negate_p(sctx.get(), r_p));
+    auto relu_p = mul_pp(sctx.get(), d_relu, p0);
+
+    /* THEN */
+    EXPECT_VALUE_EQ(s2p(sctx.get(), relu_s), relu_p);
+  });
+}
+
 #define TEST_UNARY_OP_WITH_BIT_S(OP)                                          \
   TEST_P(ApiTest, OP##S) {                                                    \
     const auto factory = std::get<0>(GetParam());                             \
@@ -288,8 +314,14 @@ TEST_P(ApiTest, MsbS) {
           auto x_s = p2s(sctx.get(), x_p);                                    \
                                                                               \
           for (auto bits : kShiftBits) {                                      \
-            if (bits >= SizeOf(conf.field()) * 8) {                           \
-              continue;                                                       \
+            if (conf.protocol() == ProtocolKind::SHAMIR) {                    \
+              if (bits >= GetMersennePrimeExp(conf.field())) {                \
+                continue;                                                     \
+              }                                                               \
+            } else {                                                          \
+              if (bits >= SizeOf(conf.field()) * 8) {                         \
+                continue;                                                     \
+              }                                                               \
             }                                                                 \
             /* WHEN */                                                        \
             auto r_s = s2p(sctx.get(), OP##_s(sctx.get(), x_s,                \
@@ -318,8 +350,14 @@ TEST_P(ApiTest, MsbS) {
             auto x_v = p2v(sctx.get(), x_p, rank);                            \
                                                                               \
             for (auto bits : kShiftBits) {                                    \
-              if (bits >= SizeOf(conf.field()) * 8) {                         \
-                continue;                                                     \
+              if (conf.protocol() == ProtocolKind::SHAMIR) {                  \
+                if (bits >= GetMersennePrimeExp(conf.field())) {              \
+                  continue;                                                   \
+                }                                                             \
+              } else {                                                        \
+                if (bits >= SizeOf(conf.field()) * 8) {                       \
+                  continue;                                                   \
+                }                                                             \
               }                                                               \
               /* WHEN */                                                      \
               auto r_v =                                                      \
@@ -349,8 +387,14 @@ TEST_P(ApiTest, MsbS) {
           auto p0 = rand_p(sctx.get(), kShape);                               \
                                                                               \
           for (auto bits : kShiftBits) { /* WHEN */                           \
-            if (bits >= SizeOf(conf.field()) * 8) {                           \
-              continue;                                                       \
+            if (conf.protocol() == ProtocolKind::SHAMIR) {                    \
+              if (bits >= GetMersennePrimeExp(conf.field())) {                \
+                continue;                                                     \
+              }                                                               \
+            } else {                                                          \
+              if (bits >= SizeOf(conf.field()) * 8) {                         \
+                continue;                                                     \
+              }                                                               \
             }                                                                 \
             auto r_p = OP##_p(sctx.get(), p0, {static_cast<int64_t>(bits)});  \
             auto r_pp = OP##_p(sctx.get(), p0, {static_cast<int64_t>(bits)}); \
@@ -384,8 +428,12 @@ TEST_P(ApiTest, TruncS) {
                                      : kShape);
 
     // TODO: here we assume has msb error, only use lowest 10 bits.
-    p0 = arshift_p(sctx.get(), p0,
-                   {static_cast<int64_t>(SizeOf(conf.field()) * 8 - 10)});
+    if (conf.protocol() == ProtocolKind::SHAMIR) {
+      p0 = arshift_p(sctx.get(), p0, {2});
+    } else {
+      p0 = arshift_p(sctx.get(), p0,
+                     {static_cast<int64_t>(SizeOf(conf.field()) * 8 - 10)});
+    }
 
     const size_t bits = 2;
     auto r_s = s2p(sctx.get(), trunc_s(sctx.get(), p2s(sctx.get(), p0), bits,
@@ -403,7 +451,7 @@ TEST_P(ApiTest, MatMulSS) {
   const size_t npc = std::get<2>(GetParam());
 
   const int64_t M = 70;
-  const int64_t K = 400;
+  const int64_t K = 40;
   const int64_t N = 60;
   const int64_t N2 = 90;
   const Shape shape_A = {M, K};

--- a/src/libspu/mpc/common/BUILD.bazel
+++ b/src/libspu/mpc/common/BUILD.bazel
@@ -28,6 +28,28 @@ spu_cc_library(
     ],
 )
 
+spu_cc_library(
+    name = "pv_gfmp",
+    srcs = ["pv_gfmp.cc"],
+    hdrs = ["pv_gfmp.h"],
+    deps = [
+        ":pv2k",
+        "//libspu/mpc:kernel",
+        "//libspu/mpc/common:communicator",
+        "//libspu/mpc/common:prg_state",
+        "//libspu/mpc/utils:gfmp_ops",
+        "//libspu/mpc/utils:ring_ops",
+    ],
+)
+
+spu_cc_test(
+    name = "pv_gfmp_test",
+    srcs = ["pv_gfmp_test.cc"],
+    deps = [
+        ":pv_gfmp",
+    ],
+)
+
 spu_cc_test(
     name = "pv2k_test",
     srcs = ["pv2k_test.cc"],

--- a/src/libspu/mpc/common/pv_gfmp.cc
+++ b/src/libspu/mpc/common/pv_gfmp.cc
@@ -1,0 +1,740 @@
+// Copyright 2024 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "libspu/mpc/common/pv_gfmp.h"
+
+#include <algorithm>
+#include <mutex>
+
+#include "libspu/core/ndarray_ref.h"
+#include "libspu/mpc/common/communicator.h"
+#include "libspu/mpc/common/prg_state.h"
+#include "libspu/mpc/common/pv2k.h"
+#include "libspu/mpc/kernel.h"
+#include "libspu/mpc/utils/gfmp.h"
+#include "libspu/mpc/utils/gfmp_ops.h"
+#include "libspu/mpc/utils/ring_ops.h"
+
+namespace spu::mpc {
+namespace {
+
+inline bool isOwner(KernelEvalContext* ctx, const Type& type) {
+  auto* comm = ctx->getState<Communicator>();
+  return type.as<PrivGfmpTy>()->owner() ==
+         static_cast<int64_t>(comm->getRank());
+}
+
+class P2V : public RevealToKernel {
+ public:
+  static constexpr const char* kBindName() { return "p2v"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& in,
+                  size_t rank) const override {
+    auto* comm = ctx->getState<Communicator>();
+    const auto field = ctx->getState<Z2kState>()->getDefaultField();
+    const auto ty = makeType<PrivGfmpTy>(field, rank);
+    if (comm->getRank() == rank) {
+      return in.as(ty);
+    } else {
+      return makeConstantArrayRef(ty, in.shape());
+    }
+  }
+};
+
+class V2P : public UnaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "v2p"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& in) const override {
+    const auto field = ctx->getState<Z2kState>()->getDefaultField();
+    size_t owner = in.eltype().as<PrivGfmpTy>()->owner();
+    auto* comm = ctx->getState<Communicator>();
+    auto out_ty = makeType<PubGfmpTy>(field);
+    NdArrayRef out = ring_zeros(field, in.shape());
+    if (comm->getRank() == owner) {
+      out = in;
+    }
+    out = comm->broadcast(out, owner, in.eltype(), in.shape(), "distribute");
+    return out.as(out_ty);
+  }
+};
+
+class MakeP : public Kernel {
+ public:
+  static constexpr const char* kBindName() { return "make_p"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  void evaluate(KernelEvalContext* ctx) const override {
+    ctx->pushOutput(
+        proc(ctx, ctx->getParam<uint128_t>(0), ctx->getParam<Shape>(1)));
+  }
+
+  static Value proc(KernelEvalContext* ctx, uint128_t init,
+                    const Shape& shape) {
+    const auto field = ctx->getState<Z2kState>()->getDefaultField();
+
+    const auto eltype = makeType<PubGfmpTy>(field);
+    auto buf = std::make_shared<yacl::Buffer>(1 * eltype.size());
+    NdArrayRef arr(buf,                       // buffer
+                   eltype,                    // eltype
+                   shape,                     // shape
+                   Strides(shape.size(), 0),  // strides
+                   0);
+
+    DISPATCH_ALL_FIELDS(field, [&]() {
+      const auto* ty = eltype.as<GfmpTy>();
+      const auto p = static_cast<ring2k_t>(ty->p());
+      const auto mp_exp = ty->mp_exp();
+      ring2k_t i = (init & p) + (init >> mp_exp);
+      arr.at<ring2k_t>(Index(shape.size(), 0)) = i >= p ? i - p : i;
+    });
+    return Value(arr, DT_INVALID);
+  }
+};
+
+class RandP : public RandKernel {
+ public:
+  static constexpr const char* kBindName() { return "rand_p"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const Shape& shape) const override {
+    auto* prg_state = ctx->getState<PrgState>();
+    const auto field = ctx->getState<Z2kState>()->getDefaultField();
+    const auto ty = makeType<PubGfmpTy>(field);
+    auto r = prg_state->genPubl(field, shape).as(ty);
+    return gfmp_mod(r).as(ty);
+  }
+};
+
+class NegateP : public UnaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "negate_p"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext*, const NdArrayRef& in) const override {
+    NdArrayRef out(in.eltype(), in.shape());
+    const auto* ty = in.eltype().as<GfmpTy>();
+    const auto field = ty->field();
+    const auto numel = in.numel();
+    DISPATCH_ALL_FIELDS(field, [&]() {
+      NdArrayView<ring2k_t> _out(out);
+      NdArrayView<ring2k_t> _in(in);
+      pforeach(0, numel, [&](int64_t idx) { _out[idx] = add_inv(_in[idx]); });
+    });
+    return out;
+  }
+};
+
+class NegateV : public UnaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "negate_v"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& in) const override {
+    if (isOwner(ctx, in.eltype())) {
+      NdArrayRef out(in.eltype(), in.shape());
+      const auto* ty = in.eltype().as<GfmpTy>();
+      const auto field = ty->field();
+      const auto numel = in.numel();
+      DISPATCH_ALL_FIELDS(field, [&]() {
+        NdArrayView<ring2k_t> _out(out);
+        NdArrayView<ring2k_t> _in(in);
+        pforeach(0, numel, [&](int64_t idx) { _out[idx] = add_inv(_in[idx]); });
+      });
+      return out;
+    } else {
+      return in;
+    }
+  }
+};
+
+class MsbP : public UnaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "msb_p"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext*, const NdArrayRef& in) const override {
+    const auto* ty = in.eltype().as<GfmpTy>();
+    const auto field = ty->field();
+    return ring_rshift(in,
+                       {static_cast<int64_t>(GetMersennePrimeExp(field) - 1)})
+        .as(in.eltype());
+  }
+};
+
+class MsbV : public UnaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "msb_v"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& in) const override {
+    if (isOwner(ctx, in.eltype())) {
+      const auto* ty = in.eltype().as<GfmpTy>();
+      const auto field = ty->field();
+      return ring_rshift(in,
+                         {static_cast<int64_t>(GetMersennePrimeExp(field) - 1)})
+          .as(in.eltype());
+    } else {
+      return in;
+    }
+  }
+};
+
+class EqualPP : public BinaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "equal_pp"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext*, const NdArrayRef& x,
+                  const NdArrayRef& y) const override {
+    SPU_ENFORCE_EQ(x.eltype(), y.eltype());
+    SPU_ENFORCE(x.eltype().isa<Pub2kTy>());
+
+    return ring_equal(x, y).as(x.eltype());
+  }
+};
+
+class EqualVVV : public BinaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "equal_vvv"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& x,
+                  const NdArrayRef& y) const override {
+    SPU_ENFORCE_EQ(x.eltype(), y.eltype());
+
+    if (isOwner(ctx, x.eltype())) {
+      return ring_equal(x, y).as(x.eltype());
+    } else {
+      return x;
+    }
+  }
+};
+
+class EqualVP : public BinaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "equal_vp"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& x,
+                  const NdArrayRef& y) const override {
+    SPU_ENFORCE_EQ(x.eltype(), y.eltype());
+
+    if (isOwner(ctx, x.eltype())) {
+      return ring_equal(x, y).as(x.eltype());
+    } else {
+      return x;
+    }
+  }
+};
+
+class AddPP : public BinaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "add_pp"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext*, const NdArrayRef& lhs,
+                  const NdArrayRef& rhs) const override {
+    SPU_ENFORCE(lhs.eltype() == rhs.eltype());
+    return gfmp_add_mod(lhs, rhs).as(lhs.eltype());
+  }
+};
+
+class AddVVV : public BinaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "add_vvv"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& lhs,
+                  const NdArrayRef& rhs) const override {
+    SPU_ENFORCE(lhs.eltype() == rhs.eltype());
+
+    if (isOwner(ctx, lhs.eltype())) {
+      return gfmp_add_mod(lhs, rhs).as(lhs.eltype());
+    } else {
+      return lhs;
+    }
+  }
+};
+
+class AddVP : public BinaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "add_vp"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& lhs,
+                  const NdArrayRef& rhs) const override {
+    if (isOwner(ctx, lhs.eltype())) {
+      return gfmp_add_mod(lhs, rhs).as(lhs.eltype());
+    } else {
+      return lhs;
+    }
+  }
+};
+
+class MulPP : public BinaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "mul_pp"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext*, const NdArrayRef& lhs,
+                  const NdArrayRef& rhs) const override {
+    SPU_ENFORCE(lhs.eltype() == rhs.eltype());
+    return gfmp_mul_mod(lhs, rhs).as(lhs.eltype());
+  }
+};
+
+class MulVP : public BinaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "mul_vp"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& lhs,
+                  const NdArrayRef& rhs) const override {
+    if (isOwner(ctx, lhs.eltype())) {
+      return gfmp_mul_mod(lhs, rhs).as(lhs.eltype());
+    } else {
+      return lhs;
+    }
+  }
+};
+
+class MulVVV : public BinaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "mul_vvv"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& lhs,
+                  const NdArrayRef& rhs) const override {
+    if (isOwner(ctx, lhs.eltype())) {
+      return gfmp_mul_mod(lhs, rhs).as(lhs.eltype());
+    } else {
+      return lhs;
+    }
+  }
+};
+
+class MatMulPP : public MatmulKernel {
+ public:
+  static constexpr const char* kBindName() { return "mmul_pp"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext*, const NdArrayRef& lhs,
+                  const NdArrayRef& rhs) const override {
+    SPU_ENFORCE(lhs.eltype() == rhs.eltype());
+    return gfmp_mmul_mod(lhs, rhs).as(lhs.eltype());
+  }
+};
+
+class MatMulVVV : public MatmulKernel {
+ public:
+  static constexpr const char* kBindName() { return "mmul_vvv"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& lhs,
+                  const NdArrayRef& rhs) const override {
+    SPU_ENFORCE(lhs.eltype() == rhs.eltype());
+    // For parties other than owner, also do a matmul to make result shape
+    // correct.
+    return gfmp_mmul_mod(lhs, rhs).as(lhs.eltype());
+  }
+};
+
+class MatMulVP : public MatmulKernel {
+ public:
+  static constexpr const char* kBindName() { return "mmul_vp"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& lhs,
+                  const NdArrayRef& rhs) const override {
+    // For parties other than owner, also do a matmul to make result shape
+    // correct.
+    return gfmp_mmul_mod(lhs, rhs).as(lhs.eltype());
+  }
+};
+
+class AndPP : public BinaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "and_pp"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext*, const NdArrayRef& lhs,
+                  const NdArrayRef& rhs) const override {
+    SPU_ENFORCE(lhs.eltype() == rhs.eltype());
+    return gfmp_mod(ring_and(lhs, rhs).as(lhs.eltype()));
+  }
+};
+
+class AndVVV : public BinaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "and_vvv"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& lhs,
+                  const NdArrayRef& rhs) const override {
+    SPU_ENFORCE(lhs.eltype() == rhs.eltype());
+    if (isOwner(ctx, lhs.eltype())) {
+      return gfmp_mod(ring_and(lhs, rhs).as(lhs.eltype()));
+    } else {
+      return lhs;
+    }
+  }
+};
+
+class AndVP : public BinaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "and_vp"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& lhs,
+                  const NdArrayRef& rhs) const override {
+    if (isOwner(ctx, lhs.eltype())) {
+      return gfmp_mod(ring_and(lhs, rhs).as(lhs.eltype()));
+    } else {
+      return lhs;
+    }
+  }
+};
+
+class XorPP : public BinaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "xor_pp"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext*, const NdArrayRef& lhs,
+                  const NdArrayRef& rhs) const override {
+    SPU_ENFORCE(lhs.eltype() == rhs.eltype());
+    return gfmp_mod(ring_xor(lhs, rhs).as(lhs.eltype()));
+  }
+};
+
+class XorVVV : public BinaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "xor_vvv"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& lhs,
+                  const NdArrayRef& rhs) const override {
+    if (isOwner(ctx, lhs.eltype())) {
+      return gfmp_mod(ring_xor(lhs, rhs).as(lhs.eltype()));
+    } else {
+      return lhs;
+    }
+  }
+};
+
+class XorVP : public BinaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "xor_vp"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& lhs,
+                  const NdArrayRef& rhs) const override {
+    if (isOwner(ctx, lhs.eltype())) {
+      return gfmp_mod(ring_xor(lhs, rhs).as(lhs.eltype()));
+    } else {
+      return lhs;
+    }
+  }
+};
+
+class LShiftP : public ShiftKernel {
+ public:
+  static constexpr const char* kBindName() { return "lshift_p"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext*, const NdArrayRef& in,
+                  const Sizes& bits) const override {
+    auto out = ring_lshift(in, bits).as(in.eltype());
+    const auto* ty = in.eltype().as<GfmpTy>();
+    const auto field = ty->field();
+    DISPATCH_ALL_FIELDS(field, [&]() {
+      ring2k_t prime = ScalarTypeToPrime<ring2k_t>::prime;
+      NdArrayView<ring2k_t> _out(out);
+      pforeach(0, in.numel(), [&](int64_t idx) { _out[idx] &= prime; });
+    });
+    return out;
+  }
+};
+
+class LShiftV : public ShiftKernel {
+ public:
+  static constexpr const char* kBindName() { return "lshift_v"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& in,
+                  const Sizes& bits) const override {
+    if (isOwner(ctx, in.eltype())) {
+      auto out = ring_lshift(in, bits).as(in.eltype());
+      const auto* ty = in.eltype().as<GfmpTy>();
+      const auto field = ty->field();
+      DISPATCH_ALL_FIELDS(field, [&]() {
+        ring2k_t prime = ScalarTypeToPrime<ring2k_t>::prime;
+        NdArrayView<ring2k_t> _out(out);
+        pforeach(0, in.numel(), [&](int64_t idx) { _out[idx] &= prime; });
+      });
+      return out;
+    } else {
+      return in;
+    }
+  }
+};
+
+class RShiftP : public ShiftKernel {
+ public:
+  static constexpr const char* kBindName() { return "rshift_p"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext*, const NdArrayRef& in,
+                  const Sizes& bits) const override {
+    return gfmp_mod(ring_rshift(in, bits).as(in.eltype()));
+  }
+};
+
+class RShiftV : public ShiftKernel {
+ public:
+  static constexpr const char* kBindName() { return "rshift_v"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& in,
+                  const Sizes& bits) const override {
+    if (isOwner(ctx, in.eltype())) {
+      return gfmp_mod(ring_rshift(in, bits).as(in.eltype()));
+    } else {
+      return in;
+    }
+  }
+};
+
+class ARShiftP : public ShiftKernel {
+ public:
+  static constexpr const char* kBindName() { return "arshift_p"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext*, const NdArrayRef& in,
+                  const Sizes& bits) const override {
+    return gfmp_arshift_mod(in, bits);
+  }
+};
+
+class ARShiftV : public ShiftKernel {
+ public:
+  static constexpr const char* kBindName() { return "arshift_v"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& in,
+                  const Sizes& bits) const override {
+    if (isOwner(ctx, in.eltype())) {
+      return gfmp_arshift_mod(in, bits);
+    } else {
+      return in;
+    }
+  }
+};
+
+class TruncP : public ShiftKernel {
+ public:
+  static constexpr const char* kBindName() { return "trunc_p"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext*, const NdArrayRef& in,
+                  const Sizes& bits) const override {
+    // Todo: round?
+    return gfmp_arshift_mod(in, bits);
+  }
+};
+
+class TruncV : public ShiftKernel {
+ public:
+  static constexpr const char* kBindName() { return "trunc_v"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& in,
+                  const Sizes& bits) const override {
+    if (isOwner(ctx, in.eltype())) {
+      // Todo: round?
+      return gfmp_arshift_mod(in, bits);
+    } else {
+      return in;
+    }
+  }
+};
+
+class BitrevP : public BitrevKernel {
+ public:
+  static constexpr const char* kBindName() { return "bitrev_p"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext*, const NdArrayRef& in, size_t start,
+                  size_t end) const override {
+    const auto field = in.eltype().as<Ring2k>()->field();
+    SPU_ENFORCE(start <= end);
+    SPU_ENFORCE(end <= SizeOf(field) * 8);
+
+    return gfmp_mod(ring_bitrev(in, start, end).as(in.eltype()));
+  }
+};
+
+class BitrevV : public BitrevKernel {
+ public:
+  static constexpr const char* kBindName() { return "bitrev_v"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& in, size_t start,
+                  size_t end) const override {
+    const auto field = in.eltype().as<Ring2k>()->field();
+    SPU_ENFORCE(start <= end);
+    SPU_ENFORCE(end <= SizeOf(field) * 8);
+
+    if (isOwner(ctx, in.eltype())) {
+      return gfmp_mod(ring_bitrev(in, start, end).as(in.eltype()));
+    } else {
+      return in;
+    }
+  }
+};
+
+}  // namespace
+
+void regPVGfmpTypes() {
+  static std::once_flag flag;
+  std::call_once(flag, []() {
+    TypeContext::getTypeContext()->addTypes<PubGfmpTy, PrivGfmpTy>();
+  });
+}
+
+void regPVGfmpKernels(Object* obj) {
+  obj->regKernel<V2P, P2V,                       //
+                 MakeP, RandP,                   //
+                 NegateV, NegateP,               //
+                 EqualVVV, EqualVP, EqualPP,     //
+                 AddVVV, AddVP, AddPP,           //
+                 MulVVV, MulVP, MulPP,           //
+                 MatMulVVV, MatMulVP, MatMulPP,  //
+                 AndVVV, AndVP, AndPP,           //
+                 XorVVV, XorVP, XorPP,           //
+                 LShiftV, LShiftP,               //
+                 RShiftV, RShiftP,               //
+                 BitrevV, BitrevP,               //
+                 ARShiftV, ARShiftP,             //
+                 MsbV, MsbP,                     //
+                 TruncV, TruncP                  //
+                 >();
+}
+
+}  // namespace spu::mpc

--- a/src/libspu/mpc/common/pv_gfmp.h
+++ b/src/libspu/mpc/common/pv_gfmp.h
@@ -1,0 +1,75 @@
+// Copyright 2024 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "libspu/core/object.h"
+#include "libspu/core/type.h"
+
+namespace spu::mpc {
+
+class PubGfmpTy : public TypeImpl<PubGfmpTy, GfmpTy, Public> {
+  using Base = TypeImpl<PubGfmpTy, GfmpTy, Public>;
+
+ public:
+  using Base::Base;
+  explicit PubGfmpTy(FieldType field) {
+    field_ = field;
+    mersenne_prime_exp_ = GetMersennePrimeExp(field);
+    prime_ = (static_cast<uint128_t>(1) << mersenne_prime_exp_) - 1;
+  }
+
+  static std::string_view getStaticId() { return "PubGfmp"; }
+};
+
+class PrivGfmpTy : public TypeImpl<PrivGfmpTy, GfmpTy, Private> {
+  using Base = TypeImpl<PrivGfmpTy, GfmpTy, Private>;
+
+ public:
+  using Base::Base;
+  explicit PrivGfmpTy(FieldType field, int64_t owner) {
+    field_ = field;
+    owner_ = owner;
+    mersenne_prime_exp_ = GetMersennePrimeExp(field);
+    prime_ = (static_cast<uint128_t>(1) << mersenne_prime_exp_) - 1;
+  }
+
+  static std::string_view getStaticId() { return "PrivGfmp"; }
+
+  std::string toString() const override {
+    return fmt::format("{},{}", FieldType_Name(field()), owner_);
+  }
+
+  void fromString(std::string_view str) override {
+    auto comma = str.find_first_of(',');
+    auto field_str = str.substr(0, comma);
+    auto owner_str = str.substr(comma + 1);
+    SPU_ENFORCE(FieldType_Parse(std::string(field_str), &field_),
+                "parse failed from={}", str);
+    owner_ = std::stoll(std::string(owner_str));
+  }
+
+  bool equals(TypeObject const* other) const override {
+    auto const* derived_other = dynamic_cast<PrivGfmpTy const*>(other);
+    SPU_ENFORCE(derived_other);
+
+    return field_ == derived_other->field_ && owner_ == derived_other->owner();
+  }
+};
+
+void regPVGfmpTypes();
+
+void regPVGfmpKernels(Object* obj);
+
+}  // namespace spu::mpc

--- a/src/libspu/mpc/common/pv_gfmp_test.cc
+++ b/src/libspu/mpc/common/pv_gfmp_test.cc
@@ -1,0 +1,73 @@
+
+// Copyright 2024 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "libspu/mpc/common/pv_gfmp.h"
+
+#include "gtest/gtest.h"
+
+namespace spu::mpc {
+
+TEST(PubGfmpTest, TypeWorks) {
+  regPVGfmpTypes();
+
+  {
+    Type ty = makeType<PubGfmpTy>(FM32);
+    EXPECT_EQ(ty.size(), 4);
+
+    EXPECT_TRUE(ty.isa<Public>());
+    EXPECT_TRUE(ty.isa<Ring2k>());
+    EXPECT_TRUE(ty.isa<GfmpTy>());
+    EXPECT_TRUE(ty.as<GfmpTy>()->mp_exp() == 31);
+    EXPECT_TRUE(ty.as<GfmpTy>()->p() == (static_cast<uint128_t>(1) << 31) - 1);
+    EXPECT_FALSE(ty.isa<Secret>());
+
+    EXPECT_EQ(ty.toString(), "PubGfmp<FM32,31>");
+
+    EXPECT_EQ(Type::fromString(ty.toString()), ty);
+  }
+  {
+    Type ty = makeType<PubGfmpTy>(FM64);
+    EXPECT_EQ(ty.size(), 8);
+
+    EXPECT_TRUE(ty.isa<Public>());
+    EXPECT_TRUE(ty.isa<Ring2k>());
+    EXPECT_TRUE(ty.isa<GfmpTy>());
+    EXPECT_TRUE(ty.as<GfmpTy>()->mp_exp() == 61);
+    EXPECT_TRUE(ty.as<GfmpTy>()->p() == (static_cast<uint128_t>(1) << 61) - 1);
+    EXPECT_FALSE(ty.isa<Secret>());
+
+    EXPECT_EQ(ty.toString(), "PubGfmp<FM64,61>");
+
+    EXPECT_EQ(Type::fromString(ty.toString()), ty);
+  }
+
+  {
+    Type ty = makeType<PubGfmpTy>(FM128);
+    EXPECT_EQ(ty.size(), 16);
+
+    EXPECT_TRUE(ty.isa<Public>());
+    EXPECT_TRUE(ty.isa<Ring2k>());
+    EXPECT_TRUE(ty.isa<Gfp>());
+    EXPECT_TRUE(ty.as<GfmpTy>()->mp_exp() == 127);
+    EXPECT_TRUE(ty.as<GfmpTy>()->p() == (static_cast<uint128_t>(1) << 127) - 1);
+    EXPECT_FALSE(ty.isa<Secret>());
+
+    EXPECT_EQ(ty.toString(), "PubGfmp<FM128,127>");
+
+    EXPECT_EQ(Type::fromString(ty.toString()), ty);
+  }
+}
+
+}  // namespace spu::mpc

--- a/src/libspu/mpc/io_shamir_test.cc
+++ b/src/libspu/mpc/io_shamir_test.cc
@@ -1,0 +1,54 @@
+// Copyright 2024 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "libspu/mpc/io_shamir_test.h"
+
+#include "gtest/gtest.h"
+
+#include "libspu/mpc/utils/gfmp_ops.h"
+#include "libspu/mpc/utils/ring_ops.h"
+
+namespace spu::mpc {
+
+const Shape kNumel = {7};
+
+TEST_P(ShamirIoTest, MakePublicAndReconstruct) {
+  const auto create_io = std::get<0>(GetParam());
+  const size_t npc = std::get<1>(GetParam());
+  const FieldType field = std::get<2>(GetParam());
+  const size_t threshold = (npc - 1) / 2;
+  auto io = create_io(field, npc, threshold);
+
+  auto raw = gfmp_rand(field, kNumel);
+  auto shares = io->toShares(raw, VIS_PUBLIC);
+  auto result = io->fromShares(shares);
+
+  EXPECT_TRUE(ring_all_equal(raw, result));
+}
+
+TEST_P(ShamirIoTest, MakeSecretAndReconstruct) {
+  const auto create_io = std::get<0>(GetParam());
+  const size_t npc = std::get<1>(GetParam());
+  const FieldType field = std::get<2>(GetParam());
+  const size_t threshold = (npc - 1) / 2;
+  auto io = create_io(field, npc, threshold);
+
+  auto raw = gfmp_rand(field, kNumel);
+  auto shares = io->toShares(raw, VIS_SECRET);
+  auto result = io->fromShares(shares);
+
+  EXPECT_TRUE(ring_all_equal(raw, result));
+}
+
+}  // namespace spu::mpc

--- a/src/libspu/mpc/io_shamir_test.h
+++ b/src/libspu/mpc/io_shamir_test.h
@@ -1,0 +1,35 @@
+// Copyright 2024 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <functional>
+
+#include "gtest/gtest.h"
+
+#include "libspu/mpc/io_interface.h"
+
+namespace spu::mpc {
+
+using CreateShamirIoFn = std::function<std::unique_ptr<IoInterface>(
+    FieldType field, size_t npc, size_t threshold)>;
+
+// This test fixture defines the standard test cases for the io interface.
+//
+// Protocol implementers should instantiate this test when a new protocol is
+// added. see
+// [here](https://google.github.io/googletest/advanced.html#creating-value-parameterized-abstract-tests)
+// for more details.
+class ShamirIoTest : public ::testing::TestWithParam<
+                         std::tuple<CreateShamirIoFn, size_t, FieldType>> {};
+
+}  // namespace spu::mpc

--- a/src/libspu/mpc/kernel.cc
+++ b/src/libspu/mpc/kernel.cc
@@ -66,6 +66,21 @@ void BinaryKernel::evaluate(KernelEvalContext* ctx) const {
   ctx->pushOutput(WrapValue(z));
 }
 
+void TernaryKnernel::evaluate(KernelEvalContext* ctx) const {
+  const auto& x = ctx->getParam<Value>(0);
+  const auto& y = ctx->getParam<Value>(1);
+  const auto& z = ctx->getParam<Value>(2);
+
+  SPU_ENFORCE(x.shape() == y.shape(), "shape mismatch {} {}", x.shape(),
+              y.shape());
+  SPU_ENFORCE(x.shape() == z.shape(), "shape mismatch {} {}", x.shape(),
+              z.shape());
+
+  auto out = proc(ctx, UnwrapValue(x), UnwrapValue(y), UnwrapValue(z));
+
+  ctx->pushOutput(WrapValue(out));
+}
+
 void MatmulKernel::evaluate(KernelEvalContext* ctx) const {
   const auto& lhs = ctx->getParam<Value>(0);
   const auto& rhs = ctx->getParam<Value>(1);
@@ -103,6 +118,17 @@ void TruncAKernel::evaluate(KernelEvalContext* ctx) const {
   SignType sign = ctx->getParam<SignType>(2);
 
   auto z = proc(ctx, UnwrapValue(in), bits, sign);
+
+  ctx->pushOutput(WrapValue(z));
+}
+
+void MulTruncAKernel::evaluate(KernelEvalContext* ctx) const {
+  const auto& lhs = ctx->getParam<Value>(0);
+  const auto& rhs = ctx->getParam<Value>(1);
+  size_t bits = ctx->getParam<size_t>(2);
+  SignType sign = ctx->getParam<SignType>(3);
+
+  auto z = proc(ctx, UnwrapValue(lhs), UnwrapValue(rhs), bits, sign);
 
   ctx->pushOutput(WrapValue(z));
 }

--- a/src/libspu/mpc/kernel.h
+++ b/src/libspu/mpc/kernel.h
@@ -52,6 +52,13 @@ class BinaryKernel : public Kernel {
                           const NdArrayRef& rhs) const = 0;
 };
 
+class TernaryKnernel : public Kernel {
+  public:
+  void evaluate(KernelEvalContext* ctx) const override;
+  virtual NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& x,
+                          const NdArrayRef& y, const NdArrayRef& z) const = 0;
+};
+
 class MatmulKernel : public Kernel {
  public:
   void evaluate(KernelEvalContext* ctx) const override;
@@ -104,6 +111,23 @@ class TruncAKernel : public Kernel {
 
   virtual NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& in,
                           size_t bits, SignType sign) const = 0;
+};
+
+class MulTruncAKernel : public Kernel {
+ public:
+  void evaluate(KernelEvalContext* ctx) const override;
+
+  // For protocol like SecureML, the most significant bit may have error with
+  // low probability, which lead to huge calculation error.
+  //
+  // Return true if the protocol has this kind of error.
+  virtual bool hasMsbError() const = 0;
+
+  virtual TruncLsbRounding lsbRounding() const = 0;
+
+  virtual NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& lhs,
+                          const NdArrayRef& rhs, size_t bits,
+                          SignType sign) const = 0;
 };
 
 class BitSplitKernel : public Kernel {

--- a/src/libspu/mpc/shamir/BUILD.bazel
+++ b/src/libspu/mpc/shamir/BUILD.bazel
@@ -1,0 +1,142 @@
+# Copyright 2024 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//bazel:spu.bzl", "spu_cc_library", "spu_cc_test")
+
+package(default_visibility = ["//visibility:public"])
+
+spu_cc_library(
+    name = "shamir",
+    deps = [
+        ":io",
+        ":protocol",
+    ],
+)
+
+spu_cc_library(
+    name = "protocol",
+    srcs = ["protocol.cc"],
+    hdrs = ["protocol.h"],
+    deps = [
+        ":arithmetic",
+        ":boolean",
+        ":conversion",
+        "//libspu/mpc/standard_shape:protocol",
+    ],
+)
+
+spu_cc_test(
+    name = "protocol_test",
+    timeout = "eternal",
+    srcs = ["protocol_test.cc"],
+    deps = [
+        ":protocol",
+        "//libspu/mpc:ab_api_test",
+        "//libspu/mpc:api_test",
+    ],
+)
+
+spu_cc_library(
+    name = "arithmetic",
+    srcs = ["arithmetic.cc"],
+    hdrs = ["arithmetic.h"],
+    deps = [
+        ":type",
+        "//libspu/core:vectorize",
+        "//libspu/mpc:ab_api",
+        "//libspu/mpc:kernel",
+        "//libspu/mpc/common:communicator",
+        "//libspu/mpc/common:pv2k",
+        "//libspu/mpc/utils:circuits",
+        "//libspu/mpc/utils:gfmp_ops",
+        "//libspu/mpc/utils:ring_ops",
+    ],
+)
+
+spu_cc_library(
+    name = "boolean",
+    srcs = ["boolean.cc"],
+    hdrs = ["boolean.h"],
+    deps = [
+        ":type",
+        ":value",
+        "//libspu/mpc:ab_api",
+        "//libspu/mpc/common:communicator",
+        "//libspu/mpc/common:prg_state",
+        "//libspu/mpc/common:pv_gfmp",
+    ],
+)
+
+spu_cc_library(
+    name = "conversion",
+    srcs = ["conversion.cc"],
+    hdrs = ["conversion.h"],
+    deps = [
+        ":value",
+        "//libspu/mpc:ab_api",
+        "//libspu/mpc:api",
+        "//libspu/mpc/common:communicator",
+        "//libspu/mpc/common:prg_state",
+        "//libspu/mpc/utils:circuits",
+        "@yacl//yacl/utils:platform_utils",
+    ],
+)
+
+spu_cc_library(
+    name = "value",
+    srcs = ["value.cc"],
+    hdrs = ["value.h"],
+    deps = [
+        ":type",
+        "//libspu/core:ndarray_ref",
+    ],
+)
+
+spu_cc_library(
+    name = "io",
+    srcs = ["io.cc"],
+    hdrs = ["io.h"],
+    deps = [
+        ":type",
+        "//libspu/mpc:io_interface",
+        "//libspu/mpc/utils:gfmp_ops",
+    ],
+)
+
+spu_cc_test(
+    name = "io_test",
+    srcs = ["io_test.cc"],
+    deps = [
+        ":io",
+        "//libspu/mpc:io_shamir_test",
+    ],
+)
+
+spu_cc_library(
+    name = "type",
+    srcs = ["type.cc"],
+    hdrs = ["type.h"],
+    deps = [
+        "//libspu/core:type",
+        "//libspu/mpc/common:pv_gfmp",
+    ],
+)
+
+spu_cc_test(
+    name = "type_test",
+    srcs = ["type_test.cc"],
+    deps = [
+        ":type",
+    ],
+)

--- a/src/libspu/mpc/shamir/arithmetic.cc
+++ b/src/libspu/mpc/shamir/arithmetic.cc
@@ -1,0 +1,430 @@
+// Copyright 2024 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "libspu/mpc/shamir/arithmetic.h"
+
+#include <functional>
+
+#include "libspu/core/type_util.h"
+#include "libspu/core/vectorize.h"
+#include "libspu/mpc/ab_api.h"
+#include "libspu/mpc/common/communicator.h"
+#include "libspu/mpc/common/prg_state.h"
+#include "libspu/mpc/common/pv2k.h"
+#include "libspu/mpc/common/pv_gfmp.h"
+#include "libspu/mpc/shamir/type.h"
+#include "libspu/mpc/utils/gfmp.h"
+#include "libspu/mpc/utils/gfmp_ops.h"
+#include "libspu/mpc/utils/ring_ops.h"
+
+namespace spu::mpc::shamir {
+
+namespace {
+
+NdArrayRef wrap_a2p(SPUContext* ctx, const NdArrayRef& x) {
+  return UnwrapValue(a2p(ctx, WrapValue(x)));
+}
+
+NdArrayRef wrap_negate_a(SPUContext* ctx, const NdArrayRef& x) {
+  return UnwrapValue(negate_a(ctx, WrapValue(x)));
+}
+
+// Generate zero sharings of degree = threshold
+NdArrayRef gen_zero_shares(KernelEvalContext* ctx, int64_t numel,
+                           int64_t threshold) {
+  const auto field = ctx->getState<Z2kState>()->getDefaultField();
+  auto* prg_state = ctx->getState<PrgState>();
+  auto* comm = ctx->getState<Communicator>();
+  auto ty = makeType<PubGfmpTy>(field);
+  auto r = prg_state->genPubl(field, {threshold * numel}).as(ty);
+  auto coeffs = gfmp_mod(r);
+  NdArrayRef zeros = ring_zeros(field, {numel}).as(makeType<GfmpTy>(field));
+  auto shares =
+      gfmp_rand_shamir_shares(zeros, coeffs, comm->getWorldSize(), threshold);
+  return shares[comm->getRank()].as(makeType<AShrTy>(field));
+}
+
+// Ref: DN'07 protocol
+//  https://www.iacr.org/archive/crypto2007/46220565/46220565.pdf
+// [Offline Phase]
+std::pair<NdArrayRef, NdArrayRef> gen_double_shares(KernelEvalContext* ctx,
+                                                    int64_t numel) {
+  auto* comm = ctx->getState<Communicator>();
+  int64_t th = ctx->sctx()->config().sss_threshold();
+  int64_t world_size = comm->getWorldSize();
+  const auto field = ctx->getState<Z2kState>()->getDefaultField();
+  auto* prg_state = ctx->getState<PrgState>();
+  auto rank = comm->getRank();
+
+  // run one-time DN protocol we can generate (world_size-th) pairs of
+  // double shares, so we need dn_times to generate multiplication double
+  // shares
+  auto dn_times = (numel - 1) / (world_size - th) + 1;
+  auto ty = makeType<AShrTy>(field);
+  auto r = gfmp_mod(prg_state->genPriv(field, {dn_times}).as(ty));
+  auto t_sh_local = gfmp_rand_shamir_shares(r, world_size, th);
+  auto t2_sh_local = gfmp_rand_shamir_shares(r, world_size, th * 2);
+
+  std::vector<NdArrayRef> t_sh_global(world_size);
+  std::vector<NdArrayRef> t2_sh_global(world_size);
+
+  // Todo: optimize this ugly off-line code
+  for (size_t i = 0; i < t_sh_local.size(); ++i) {
+    if (i != rank) {
+      auto share = t_sh_local[i].concatenate({t2_sh_local[i]}, 0);
+      comm->sendAsync(i, share, "send share");
+    }
+  }
+  for (size_t i = 0; i < t_sh_local.size(); ++i) {
+    if (i != rank) {
+      auto share = comm->recv(i, ty, "recv share");
+      t_sh_global[i] = share.slice({0}, {dn_times}, {});
+      t2_sh_global[i] = share.slice({dn_times}, {2 * dn_times}, {});
+    }
+  }
+  t_sh_global[rank] = t_sh_local[rank];
+  t2_sh_global[rank] = t2_sh_local[rank];
+
+  std::pair<NdArrayRef, NdArrayRef> out{
+      NdArrayRef(ty, {dn_times * (world_size - th)}),
+      NdArrayRef(ty, {dn_times * (world_size - th)})};
+
+  // generate random double shares
+  DISPATCH_ALL_FIELDS(field, [&]() {
+    NdArrayView<ring2k_t> _r_t(out.first);
+    NdArrayView<ring2k_t> _r_2t(out.second);
+    auto van = GenVandermondeMatrix<ring2k_t>(world_size, world_size - th);
+    pforeach(0, dn_times, [&](int64_t idx) {
+      // Optimize me: no copy need here
+      GfmpMatrix<ring2k_t> s_t(1, world_size);
+      GfmpMatrix<ring2k_t> s_2t(1, world_size);
+      for (auto i = 0; i < world_size; ++i) {
+        NdArrayView<ring2k_t> _share_t(t_sh_global[i]);
+        NdArrayView<ring2k_t> _share_2t(t2_sh_global[i]);
+        s_t(0, i) = Gfmp<ring2k_t>(_share_t[idx]);
+        s_2t(0, i) = Gfmp<ring2k_t>(_share_2t[idx]);
+      }
+      auto ret_t = s_t * van;
+      auto ret_2t = s_2t * van;
+
+      for (auto i = 0; i < (world_size - th); ++i) {
+        _r_t[idx * (world_size - th) + i] = ret_t(0, i).data();
+        _r_2t[idx * (world_size - th) + i] = ret_2t(0, i).data();
+      }
+    });
+  });
+  return out;
+}
+
+}  // namespace
+
+// Ref: DN'07 protocol for honesty majority
+//  https://www.iacr.org/archive/crypto2007/46220565/46220565.pdf
+// [Offline Phase]
+NdArrayRef RandA::proc(KernelEvalContext* ctx, const Shape& shape) const {
+  auto* prg_state = ctx->getState<PrgState>();
+  auto* comm = ctx->getState<Communicator>();
+  const auto field = ctx->getState<Z2kState>()->getDefaultField();
+  NdArrayRef out = ring_zeros(field, shape);
+  int64_t world_size = comm->getWorldSize();
+  int64_t th = ctx->sctx()->config().sss_threshold();
+  int64_t numel = shape.numel();
+
+  // run one-time DN protocol we can generate (world_size-th) random shares
+  auto dn_times = (numel - 1) / (world_size - th) + 1;
+  auto ty = makeType<GfmpTy>(field);
+  auto r = gfmp_mod(prg_state->genPriv(field, {dn_times}).as(ty));
+  auto shares_r = gfmp_rand_shamir_shares(r, world_size, th);
+  auto rank = comm->getRank();
+
+  std::vector<NdArrayRef> r_shrs(world_size);
+  for (size_t i = 0; i < shares_r.size(); ++i) {
+    if (i != rank) {
+      comm->sendAsync(i, shares_r[i], "send r_share");
+    }
+  }
+  for (size_t i = 0; i < shares_r.size(); ++i) {
+    if (i != rank) {
+      r_shrs[i] = comm->recv(i, shares_r[i].eltype(), "send r_share");
+    }
+  }
+  comm->addCommStatsManually(1, r.elsize() * r.numel() * (world_size - 1));
+
+  r_shrs[rank] = shares_r[rank];
+  return DISPATCH_ALL_FIELDS(field, [&]() {
+    NdArrayRef r_t(ty, {dn_times * (world_size - th)});
+    NdArrayView<ring2k_t> _r_t(r_t);
+    auto van = GenVandermondeMatrix<ring2k_t>(world_size, world_size - th);
+    // TODO optimize me: all random shares can be done by a mmut between van^T *
+    // r_shrs van^T is a n-t by n r_shrs is a n by dn_times matrix
+    pforeach(0, dn_times, [&](int64_t idx) {
+      GfmpMatrix<ring2k_t> s_t(1, world_size);
+      for (auto i = 0; i < world_size; ++i) {
+        NdArrayView<ring2k_t> _r_shrs(r_shrs[i]);
+        s_t(0, i) = Gfmp<ring2k_t>(_r_shrs[idx]);
+      }
+      auto ret_t = s_t * van;
+
+      for (auto i = 0; i < (world_size - th); ++i) {
+        _r_t[idx * (world_size - th) + i] = ret_t(0, i).data();
+      }
+    });
+    auto out = r_t.slice({0}, {numel}, {});
+    return out.as(makeType<AShrTy>(field));
+  });
+}
+
+NdArrayRef P2A::proc(KernelEvalContext* ctx, const NdArrayRef& in) const {
+  const auto field = in.eltype().as<Ring2k>()->field();
+  return in.as(makeType<AShrTy>(field));
+}
+
+NdArrayRef A2P::proc(KernelEvalContext* ctx, const NdArrayRef& in) const {
+  const auto field = in.eltype().as<GfmpTy>()->field();
+  auto* comm = ctx->getState<Communicator>();
+  // we choose rank 0 as the P_pking for reconstructing secrets
+  auto arrays = comm->gather(in, 0, "send to pking");
+  NdArrayRef out = ring_zeros(field, in.shape());
+  if (comm->getRank() == 0) {
+    out = gfmp_reconstruct_shamir_shares(arrays, comm->getWorldSize(),
+                                         ctx->sctx()->config().sss_threshold());
+  }
+  out = comm->broadcast(out, 0, in.eltype(), in.shape(), "distribute");
+  return out.as(makeType<PubGfmpTy>(field));
+}
+
+NdArrayRef A2V::proc(KernelEvalContext* ctx, const NdArrayRef& in,
+                     size_t rank) const {
+  auto* comm = ctx->getState<Communicator>();
+  const auto field = in.eltype().as<AShrTy>()->field();
+  auto out_ty = makeType<PrivGfmpTy>(field, rank);
+  auto arrays = comm->gather(in, rank, "gather");
+  if (comm->getRank() == rank) {
+    SPU_ENFORCE(arrays.size() == comm->getWorldSize());
+    auto out = gfmp_reconstruct_shamir_shares(
+        arrays, comm->getWorldSize(), ctx->sctx()->config().sss_threshold());
+    return out.as(out_ty);
+  } else {
+    return makeConstantArrayRef(out_ty, in.shape());
+  }
+}
+
+NdArrayRef V2A::proc(KernelEvalContext* ctx, const NdArrayRef& in) const {
+  const auto* in_ty = in.eltype().as<PrivGfmpTy>();
+  const size_t owner_rank = in_ty->owner();
+  const auto field = in_ty->field();
+  auto* comm = ctx->getState<Communicator>();
+  auto out_ty = makeType<AShrTy>(field);
+  auto th = ctx->sctx()->config().sss_threshold();
+  NdArrayRef out;
+  if (comm->getRank() == owner_rank) {
+    auto shares = gfmp_rand_shamir_shares(in, comm->getWorldSize(), th);
+    for (size_t i = 0; i < shares.size(); ++i) {
+      if (i != owner_rank) {
+        comm->sendAsync(i, shares[i], "v2a");
+      }
+    }
+    out = shares[owner_rank];
+  } else {
+    out = comm->recv(owner_rank, out_ty, "v2a");
+  }
+  comm->addCommStatsManually(1, in.elsize() * in.numel());
+  return out.reshape(in.shape()).as(out_ty);
+}
+
+NdArrayRef NegateA::proc(KernelEvalContext*, const NdArrayRef& in) const {
+  NdArrayRef out(in.eltype(), in.shape());
+  const auto* ty = in.eltype().as<GfmpTy>();
+  const auto field = ty->field();
+  const auto numel = in.numel();
+  DISPATCH_ALL_FIELDS(field, [&]() {
+    NdArrayView<ring2k_t> _out(out);
+    NdArrayView<ring2k_t> _in(in);
+    pforeach(0, numel, [&](int64_t idx) { _out[idx] = add_inv(_in[idx]); });
+  });
+  return out;
+}
+
+////////////////////////////////////////////////////////////////////
+// add family
+////////////////////////////////////////////////////////////////////
+NdArrayRef AddAP::proc(KernelEvalContext* ctx, const NdArrayRef& lhs,
+                       const NdArrayRef& rhs) const {
+  SPU_ENFORCE(lhs.numel() == rhs.numel());
+  auto ret = gfmp_add_mod(lhs, rhs);
+  return ret.as(lhs.eltype());
+}
+
+NdArrayRef AddAA::proc(KernelEvalContext*, const NdArrayRef& lhs,
+                       const NdArrayRef& rhs) const {
+  SPU_ENFORCE(lhs.numel() == rhs.numel());
+  SPU_ENFORCE(lhs.eltype() == rhs.eltype());
+  return gfmp_add_mod(lhs, rhs).as(lhs.eltype());
+}
+
+////////////////////////////////////////////////////////////////////
+// multiply family
+////////////////////////////////////////////////////////////////////
+NdArrayRef MulAP::proc(KernelEvalContext*, const NdArrayRef& lhs,
+                       const NdArrayRef& rhs) const {
+  return gfmp_mul_mod(lhs, rhs).as(lhs.eltype());
+}
+
+// Ref: DN'07 protocol
+//  https://www.iacr.org/archive/crypto2007/46220565/46220565.pdf
+NdArrayRef MulAA::proc(KernelEvalContext* ctx, const NdArrayRef& lhs,
+                       const NdArrayRef& rhs) const {
+  SPU_ENFORCE(lhs.numel() == rhs.numel());
+  SPU_ENFORCE_EQ(lhs.eltype(), rhs.eltype());
+
+  // local mul
+  auto tmp_2t = gfmp_mul_mod(lhs, rhs).as(lhs.eltype());
+  NdArrayRef out(lhs.eltype(), lhs.shape());
+
+  // reduction degree
+  const auto field = lhs.eltype().as<Ring2k>()->field();
+  auto numel = lhs.numel();
+
+  NdArrayRef r_t;
+  NdArrayRef r_2t;
+  std::tie(r_t, r_2t) = gen_double_shares(ctx, numel);
+
+  DISPATCH_ALL_FIELDS(field, [&]() {
+    // generate double shares
+    NdArrayView<ring2k_t> _r_t(r_t);
+    NdArrayView<ring2k_t> _r_2t(r_2t);
+    NdArrayView<ring2k_t> _out(out);
+    NdArrayView<ring2k_t> _tmp_2t(tmp_2t);
+    NdArrayRef d(lhs.eltype(), lhs.shape());
+    NdArrayView<ring2k_t> _d(d);
+    pforeach(0, numel,
+             [&](int64_t idx) { _d[idx] = add_mod(_tmp_2t[idx], _r_2t[idx]); });
+    auto revealed_d = wrap_a2p(ctx->sctx(), d);
+    NdArrayView<ring2k_t> _revealed_d(revealed_d);
+    pforeach(0, numel, [&](int64_t idx) {
+      _out[idx] = add_mod(_revealed_d[idx], add_inv(_r_t[idx]));
+    });
+  });
+  return out;
+}
+
+// Two Layer Multiplication with only 1 round
+// Ref: ATLAS
+NdArrayRef MulAAA::proc(KernelEvalContext* ctx, const NdArrayRef& x, const NdArrayRef& y, const NdArrayRef& z) const {
+  SPU_ENFORCE(x.numel() == y.numel());
+  SPU_ENFORCE(x.numel() == z.numel());
+  SPU_ENFORCE_EQ(x.eltype(), y.eltype());
+  SPU_ENFORCE_EQ(x.eltype(), z.eltype());
+
+  NdArrayRef r_t;
+  NdArrayRef r_2t;
+  auto numel = x.numel();
+  std::tie(r_t, r_2t) = gen_double_shares(ctx, numel<<1);
+
+  const auto field = x.eltype().as<Ring2k>()->field();
+  auto xy_2t = gfmp_mul_mod(x, y).as(x.eltype());
+  auto minus_rz_2t = gfmp_mul_mod(r_t.slice({0}, {numel}, {}).reshape(z.shape()), wrap_negate_a(ctx->sctx(), z)).as(x.eltype());
+
+  NdArrayRef out(x.eltype(), x.shape());
+  DISPATCH_ALL_FIELDS(field, [&]() {
+    NdArrayView<ring2k_t> _r_t(r_t);
+    NdArrayView<ring2k_t> _r_2t(r_2t);
+    NdArrayView<ring2k_t> _xy_2t(xy_2t);
+    NdArrayView<ring2k_t> _rz_2t(minus_rz_2t);
+    NdArrayView<ring2k_t> _z(z);
+    NdArrayView<ring2k_t> _out(out);
+    NdArrayRef d(x.eltype(), {x.numel()<<1});
+    NdArrayView<ring2k_t> _d(d);
+    pforeach(0, numel, [&](int64_t idx) {
+      _d[idx] = add_mod(_xy_2t[idx], _r_2t[idx]);
+    });
+    pforeach(0, numel, [&](int64_t idx) {
+      _d[idx + numel] = add_mod(_rz_2t[idx], _r_2t[idx + numel]);
+    });
+    NdArrayRef u = wrap_a2p(ctx->sctx(), d);
+    NdArrayView<ring2k_t> _u(u);
+
+    pforeach(0, numel, [&](int64_t idx) {
+      _out[idx] = add_mod(mul_mod(_u[idx], _z[idx]), add_mod(_u[numel + idx], add_inv(_r_t[numel + idx])));
+    });
+  });
+  return out;
+}
+
+// Combine MulAA and A2P in 1 round
+NdArrayRef MulAAP::proc(KernelEvalContext* ctx, const NdArrayRef& lhs,
+                        const NdArrayRef& rhs) const {
+  SPU_ENFORCE(lhs.numel() == rhs.numel());
+  SPU_ENFORCE_EQ(lhs.eltype(), rhs.eltype());
+  const auto field = lhs.eltype().as<Ring2k>()->field();
+
+  // local mul
+  auto tmp_2t = gfmp_mul_mod(lhs, rhs).as(lhs.eltype());
+
+  // generate zero sharings of degree-2t
+  auto zero_shares = gen_zero_shares(
+      ctx, lhs.numel(), ctx->sctx()->config().sss_threshold() << 1);
+
+  // add zero sharings
+  NdArrayRef out(lhs.eltype(), lhs.shape());
+  DISPATCH_ALL_FIELDS(field, [&]() {
+    NdArrayView<ring2k_t> _zero(zero_shares);
+    NdArrayView<ring2k_t> _tmp_2t(tmp_2t);
+    NdArrayView<ring2k_t> _out(out);
+    pforeach(0, lhs.numel(), [&](int64_t idx) {
+      _out[idx] = add_mod(_tmp_2t[idx], _zero[idx]);
+    });
+  });
+
+  return wrap_a2p(ctx->sctx(), out);
+}
+
+////////////////////////////////////////////////////////////////////
+// matmul family
+////////////////////////////////////////////////////////////////////
+NdArrayRef MatMulAP::proc(KernelEvalContext*, const NdArrayRef& x,
+                          const NdArrayRef& y) const {
+  return gfmp_mmul_mod(x, y).as(x.eltype());
+}
+
+NdArrayRef MatMulAA::proc(KernelEvalContext* ctx, const NdArrayRef& x,
+                          const NdArrayRef& y) const {
+  const auto field = x.eltype().as<GfmpTy>()->field();
+
+  return DISPATCH_ALL_FIELDS(field, [&]() {
+    // local matmul
+    NdArrayRef tmp_2t = gfmp_mmul_mod(x, y);
+    NdArrayView<ring2k_t> _tmp_2t(tmp_2t);
+    // degree reduction
+    NdArrayRef out(tmp_2t.eltype(), tmp_2t.shape());
+    NdArrayRef r_t;
+    NdArrayRef r_2t;
+    std::tie(r_t, r_2t) = gen_double_shares(ctx, tmp_2t.numel());
+    NdArrayView<ring2k_t> _r_t(r_t);
+    NdArrayView<ring2k_t> _r_2t(r_2t);
+    NdArrayView<ring2k_t> _out(out);
+    NdArrayRef d(out.eltype(), out.shape());
+    NdArrayView<ring2k_t> _d(d);
+    pforeach(0, tmp_2t.numel(),
+             [&](int64_t idx) { _d[idx] = add_mod(_tmp_2t[idx], _r_2t[idx]); });
+    auto revealed_d = wrap_a2p(ctx->sctx(), d);
+    NdArrayView<ring2k_t> _revealed_d(revealed_d);
+    pforeach(0, out.numel(), [&](int64_t idx) {
+      _out[idx] = add_mod(_revealed_d[idx], add_inv(_r_t[idx]));
+    });
+    return out;
+  });
+};
+
+}  // namespace spu::mpc::shamir

--- a/src/libspu/mpc/shamir/arithmetic.h
+++ b/src/libspu/mpc/shamir/arithmetic.h
@@ -1,0 +1,208 @@
+// Copyright 2024 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "libspu/mpc/kernel.h"
+
+namespace spu::mpc::shamir {
+
+class RandA : public RandKernel {
+ public:
+  static constexpr const char* kBindName() { return "rand_a"; }
+
+  Kind kind() const override { return Kind::Dynamic; }
+
+  ce::CExpr latency() const override { return ce::Const(1); }
+
+  ce::CExpr comm() const override {
+    auto dy_times = ce::Variable(
+        "D", "dynamic_times = ceil(numl / (n-t)) = [(numel – 1) / (n-t) + 1]");
+    return (ce::N() - 1) * ce::K() * dy_times;
+  }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const Shape& shape) const override;
+};
+
+class P2A : public UnaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "p2a"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& in) const override;
+};
+
+class A2P : public UnaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "a2p"; }
+
+  ce::CExpr latency() const override { return ce::Const(2); }
+
+  ce::CExpr comm() const override { return ce::K() * 2; }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& in) const override;
+};
+
+class A2V : public RevealToKernel {
+ public:
+  static constexpr const char* kBindName() { return "a2v"; }
+
+  ce::CExpr latency() const override { return ce::Const(1); }
+
+  ce::CExpr comm() const override { return ce::K(); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& in,
+                  size_t rank) const override;
+};
+
+class V2A : public UnaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "v2a"; }
+
+  ce::CExpr latency() const override { return ce::Const(1); }
+
+  ce::CExpr comm() const override { return ce::K(); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& in) const override;
+};
+
+class NegateA : public UnaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "negate_a"; }
+
+  Kind kind() const override { return Kind::Dynamic; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& in) const override;
+};
+
+////////////////////////////////////////////////////////////////////
+// add family
+////////////////////////////////////////////////////////////////////
+class AddAP : public BinaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "add_ap"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& lhs,
+                  const NdArrayRef& rhs) const override;
+};
+
+class AddAA : public BinaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "add_aa"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& lhs,
+                  const NdArrayRef& rhs) const override;
+};
+
+////////////////////////////////////////////////////////////////////
+// multiply family
+////////////////////////////////////////////////////////////////////
+class MulAP : public BinaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "mul_ap"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& lhs,
+                  const NdArrayRef& rhs) const override;
+};
+
+class MulAA : public BinaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "mul_aa"; }
+
+  ce::CExpr latency() const override { return ce::Const(2); }
+
+  ce::CExpr comm() const override { return ce::K() * 2; }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& lhs,
+                  const NdArrayRef& rhs) const override;
+};
+
+class MulAAA : public TernaryKnernel {
+ public:
+  static constexpr const char* kBindName() { return "mul_aaa"; }
+
+  ce::CExpr latency() const override { return ce::Const(2); }
+
+  ce::CExpr comm() const override { return ce::K() * 4; }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& x,
+                  const NdArrayRef& y, const NdArrayRef& z) const override;
+};
+
+class MulAAP : public BinaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "mul_aa_p"; }
+
+  ce::CExpr latency() const override { return ce::Const(1); }
+
+  ce::CExpr comm() const override { return ce::K() * 2; }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& lhs,
+                  const NdArrayRef& rhs) const override;
+};
+
+////////////////////////////////////////////////////////////////////
+// matmul family
+////////////////////////////////////////////////////////////////////
+class MatMulAP : public MatmulKernel {
+ public:
+  static constexpr const char* kBindName() { return "mmul_ap"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& x,
+                  const NdArrayRef& y) const override;
+};
+
+class MatMulAA : public MatmulKernel {
+ public:
+  static constexpr const char* kBindName() { return "mmul_aa"; }
+
+  ce::CExpr latency() const override {
+    // only count online for now.
+    return ce::Const(2);
+  }
+
+  ce::CExpr comm() const override {
+    auto m = ce::Variable("m", "rows of lhs");
+    auto n = ce::Variable("n", "cols of rhs");
+    return ce::K() * 2 * (m * n);
+  }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& x,
+                  const NdArrayRef& y) const override;
+};
+
+}  // namespace spu::mpc::shamir

--- a/src/libspu/mpc/shamir/boolean.cc
+++ b/src/libspu/mpc/shamir/boolean.cc
@@ -1,0 +1,475 @@
+// Copyright 2024 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "libspu/mpc/shamir/boolean.h"
+
+#include <algorithm>
+
+#include "libspu/core/bit_utils.h"
+#include "libspu/core/parallel_utils.h"
+#include "libspu/mpc/ab_api.h"
+#include "libspu/mpc/common/communicator.h"
+#include "libspu/mpc/common/prg_state.h"
+#include "libspu/mpc/common/pv2k.h"
+#include "libspu/mpc/common/pv_gfmp.h"
+#include "libspu/mpc/shamir/type.h"
+#include "libspu/mpc/shamir/value.h"
+#include "libspu/mpc/utils/gfmp.h"
+#include "libspu/mpc/utils/gfmp_ops.h"
+#include "libspu/mpc/utils/ring_ops.h"
+
+namespace spu::mpc::shamir {
+
+namespace {
+
+size_t getNumBits(const NdArrayRef& in) {
+  if (in.eltype().isa<PubGfmpTy>()) {
+    const auto field = in.eltype().as<PubGfmpTy>()->field();
+    return DISPATCH_ALL_FIELDS(field,
+                               [&]() { return maxBitWidth<ring2k_t>(in); });
+  } else if (in.eltype().isa<BShrTy>()) {
+    return in.eltype().as<BShrTy>()->nbits();
+  } else {
+    SPU_THROW("should not be here, {}", in.eltype());
+  }
+}
+
+NdArrayRef wrap_mul_aa(SPUContext* ctx, const NdArrayRef& x,
+                       const NdArrayRef& y) {
+  return UnwrapValue(mul_aa(ctx, WrapValue(x), WrapValue(y)));
+}
+
+NdArrayRef wrap_p2a(SPUContext* ctx, const NdArrayRef& x) {
+  return UnwrapValue(p2a(ctx, WrapValue(x)));
+}
+
+NdArrayRef wrap_a2p(SPUContext* ctx, const NdArrayRef& x) {
+  return UnwrapValue(a2p(ctx, WrapValue(x)));
+}
+
+NdArrayRef wrap_a2v(SPUContext* ctx, const NdArrayRef& x, size_t rank) {
+  return UnwrapValue(a2v(ctx, WrapValue(x), rank));
+}
+
+NdArrayRef wrap_b2a(SPUContext* ctx, const NdArrayRef& x) {
+  return UnwrapValue(b2a(ctx, WrapValue(x)));
+}
+
+}  // namespace
+
+void CommonTypeB::evaluate(KernelEvalContext* ctx) const {
+  const Type& lhs = ctx->getParam<Type>(0);
+  const Type& rhs = ctx->getParam<Type>(1);
+
+  const size_t lhs_nbits = lhs.as<BShrTy>()->nbits();
+  const size_t rhs_nbits = rhs.as<BShrTy>()->nbits();
+
+  const size_t out_nbits = std::max(lhs_nbits, rhs_nbits);
+  const auto field = lhs.as<BShrTy>()->field();
+  ctx->pushOutput(makeType<BShrTy>(field, out_nbits));
+}
+
+NdArrayRef CastTypeB::proc(KernelEvalContext*, const NdArrayRef& in,
+                           const Type& to_type) const {
+  NdArrayRef out(to_type, in.shape());
+  const size_t in_nbits = in.eltype().as<BShrTy>()->nbits();
+  const size_t out_nbits = to_type.as<BShrTy>()->nbits();
+  SPU_ENFORCE_GE(out_nbits, in_nbits);
+  memset(out.data(), 0, out.numel() * out.elsize());
+  // FIXME: optimize me, all the following things are memory copies
+  for (int64_t idx = 0; idx < static_cast<int64_t>(in_nbits); ++idx) {
+    auto in_i = getBitShare(in, idx);
+    auto out_i = getBitShare(out, idx);
+    ring_assign(out_i, in_i);
+  }
+  return out;
+}
+
+NdArrayRef B2P::proc(KernelEvalContext* ctx, const NdArrayRef& in) const {
+  return wrap_a2p(ctx->sctx(), wrap_b2a(ctx->sctx(), in));
+}
+
+NdArrayRef P2B::proc(KernelEvalContext* ctx, const NdArrayRef& in) const {
+  const auto* in_ty = in.eltype().as<PubGfmpTy>();
+  const auto field = in_ty->field();
+
+  return DISPATCH_ALL_FIELDS(field, [&]() {
+    const size_t nbits = maxBitWidth<ring2k_t>(in);
+    const auto out_ty = makeType<BShrTy>(field, nbits);
+    NdArrayRef out(out_ty, in.shape());
+    NdArrayView<ring2k_t> _in(in);
+
+    std::vector<NdArrayRef> bits;
+    for (size_t i = 0; i < nbits; ++i) {
+      NdArrayRef bit_i_p(makeType<AShrTy>(field), in.shape());
+      NdArrayView<ring2k_t> _bit_i_p(bit_i_p);
+      pforeach(0, in.numel(), [&](int64_t idx) {
+        _bit_i_p[idx] = static_cast<ring2k_t>(_in[idx] >> i) & 1U;
+      });
+      bits.push_back(std::move(bit_i_p));
+    }
+    std::vector<NdArrayRef> bits_a;
+    vmap(bits.begin(), bits.end(), std::back_inserter(bits_a),
+         [ctx](const NdArrayRef& a) { return wrap_p2a(ctx->sctx(), a); });
+    for (size_t i = 0; i < nbits; ++i) {
+      NdArrayRef bit_i_b = getBitShare(out, i);
+      ring_assign(bit_i_b, bits_a[i]);
+    }
+    return out;
+  });
+}
+
+NdArrayRef B2V::proc(KernelEvalContext* ctx, const NdArrayRef& in,
+                     size_t rank) const {
+  return wrap_a2v(ctx->sctx(), wrap_b2a(ctx->sctx(), in), rank);
+}
+
+NdArrayRef AndBP::proc(KernelEvalContext*, const NdArrayRef& lhs,
+                       const NdArrayRef& rhs) const {
+  const auto* lhs_ty = lhs.eltype().as<BShrTy>();
+  const auto* rhs_ty = rhs.eltype().as<PubGfmpTy>();
+  auto b_field = lhs_ty->field();
+  const size_t out_nbits = std::min(lhs_ty->nbits(), getNumBits(rhs));
+  auto out_ty = makeType<BShrTy>(b_field, out_nbits);
+  NdArrayRef out(out_ty, lhs.shape());
+  DISPATCH_ALL_FIELDS(b_field, [&]() {
+    using LT = ring2k_t;
+    DISPATCH_ALL_FIELDS(rhs_ty->field(), [&]() {
+      using RT = ring2k_t;
+      for (size_t i = 0; i < out_nbits; ++i) {
+        auto lhs_i = getBitShare(lhs, i);
+        auto out_i = getBitShare(out, i);
+        NdArrayView<LT> _lhs_i(lhs_i);
+        NdArrayView<LT> _out_i(out_i);
+        NdArrayView<RT> _rhs(rhs);
+        pforeach(0, lhs.numel(), [&](int64_t idx) {
+          _out_i[idx] =
+              mul_mod(static_cast<LT>((_rhs[idx] >> i) & 1U), _lhs_i[idx]);
+        });
+      }
+    });
+  });
+  return out;
+}
+
+NdArrayRef AndBB::proc(KernelEvalContext* ctx, const NdArrayRef& lhs,
+                       const NdArrayRef& rhs) const {
+  const auto* lhs_ty = lhs.eltype().as<BShrTy>();
+  const auto* rhs_ty = rhs.eltype().as<BShrTy>();
+  SPU_ENFORCE_EQ(lhs_ty->field(), rhs_ty->field());
+  auto b_field = lhs_ty->field();
+  const size_t out_nbits = std::min(lhs_ty->nbits(), rhs_ty->nbits());
+  auto out_ty = makeType<BShrTy>(b_field, out_nbits);
+  NdArrayRef out(out_ty, lhs.shape());
+
+  auto and_lambda = [ctx](const NdArrayRef& a, const NdArrayRef& b) {
+    return wrap_mul_aa(ctx->sctx(), a, b);
+  };
+
+  std::vector<NdArrayRef> lhs_bits;
+  std::vector<NdArrayRef> rhs_bits;
+  for (size_t i = 0; i < out_nbits; ++i) {
+    lhs_bits.push_back(getBitShare(lhs, i));
+    rhs_bits.push_back(getBitShare(rhs, i));
+  }
+  std::vector<NdArrayRef> tmp_out;
+  vmap(lhs_bits.begin(), lhs_bits.end(), rhs_bits.begin(), rhs_bits.end(),
+       std::back_inserter(tmp_out), and_lambda);
+  for (size_t i = 0; i < out_nbits; ++i) {
+    auto out_i = getBitShare(out, i);
+    ring_assign(out_i, tmp_out[i]);
+  }
+  return out;
+}
+
+NdArrayRef XorBP::proc(KernelEvalContext*, const NdArrayRef& lhs,
+                       const NdArrayRef& rhs) const {
+  const auto* lhs_ty = lhs.eltype().as<BShrTy>();
+  const auto* rhs_ty = rhs.eltype().as<PubGfmpTy>();
+  auto b_field = lhs_ty->field();
+  const size_t l_nbits = lhs_ty->nbits();
+  const size_t r_nbits = getNumBits(rhs);
+  const size_t out_nbits = std::max(l_nbits, r_nbits);
+  const size_t common_nbits = std::min(l_nbits, r_nbits);
+  auto out_ty = makeType<BShrTy>(b_field, out_nbits);
+  NdArrayRef out(out_ty, lhs.shape());
+  DISPATCH_ALL_FIELDS(b_field, [&]() {
+    using LT = ring2k_t;
+    DISPATCH_ALL_FIELDS(rhs_ty->field(), [&]() {
+      using RT = ring2k_t;
+      // calculate common bits
+      for (size_t i = 0; i < common_nbits; ++i) {
+        auto lhs_i = getBitShare(lhs, i);
+        auto out_i = getBitShare(out, i);
+        NdArrayView<LT> _lhs_i(lhs_i);
+        NdArrayView<LT> _out_i(out_i);
+        NdArrayView<RT> _rhs(rhs);
+        // x ^ y = (x + y) - 2 * (x * y) for x,y in [0,1]
+        pforeach(0, lhs.numel(), [&](int64_t idx) {
+          LT _x = _lhs_i[idx];
+          LT _y = static_cast<LT>((_rhs[idx] >> i) & 1U);
+          _out_i[idx] =
+              add_mod(add_mod(_x, _y),
+                      add_inv(mul_mod(static_cast<LT>(2), mul_mod(_x, _y))));
+        });
+      }
+      // calculate the rest bits
+      for (size_t i = common_nbits; i < out_nbits; ++i) {
+        auto out_i = getBitShare(out, i);
+        if (l_nbits > r_nbits) {
+          auto more_bit_share = getBitShare(lhs, i);
+          ring_assign(out_i, more_bit_share);
+        } else {
+          NdArrayView<LT> _out_i(out_i);
+          NdArrayView<RT> _rhs(rhs);
+          pforeach(0, lhs.numel(), [&](int64_t idx) {
+            _out_i[idx] = static_cast<LT>((_rhs[idx] >> i) & 1U);
+          });
+        }
+      }
+    });
+  });
+  return out;
+}
+
+NdArrayRef XorBB::proc(KernelEvalContext* ctx, const NdArrayRef& lhs,
+                       const NdArrayRef& rhs) const {
+  const auto* lhs_ty = lhs.eltype().as<BShrTy>();
+  const auto* rhs_ty = rhs.eltype().as<BShrTy>();
+
+  SPU_ENFORCE_EQ(lhs_ty->field(), rhs_ty->field());
+  auto b_field = lhs_ty->field();
+  const size_t l_nbits = lhs_ty->nbits();
+  const size_t r_nbits = rhs_ty->nbits();
+  const size_t out_nbits = std::max(l_nbits, r_nbits);
+  const size_t common_nbits = std::min(l_nbits, r_nbits);
+  auto out_ty = makeType<BShrTy>(b_field, out_nbits);
+  NdArrayRef out(out_ty, lhs.shape());
+  DISPATCH_ALL_FIELDS(b_field, [&]() {
+    // calculate common bits
+    auto xor_lambda = [ctx](const NdArrayRef& a, const NdArrayRef& b) {
+      auto tmp = wrap_mul_aa(ctx->sctx(), a, b);
+      NdArrayRef xor_ret(a.eltype(), a.shape());
+      NdArrayView<ring2k_t> _xor_ret(xor_ret);
+      NdArrayView<ring2k_t> _a(a);
+      NdArrayView<ring2k_t> _b(b);
+      NdArrayView<ring2k_t> _tmp(tmp);
+      // x ^ y = (x + y) - 2 * (x * y) for x,y in [0,1]
+      pforeach(0, a.numel(), [&](int64_t idx) {
+        _xor_ret[idx] =
+            add_mod(add_mod(_a[idx], _b[idx]),
+                    add_inv(mul_mod(static_cast<ring2k_t>(2), _tmp[idx])));
+      });
+      return xor_ret;
+    };
+
+    std::vector<NdArrayRef> lhs_bits;
+    std::vector<NdArrayRef> rhs_bits;
+    for (size_t i = 0; i < common_nbits; ++i) {
+      lhs_bits.push_back(getBitShare(lhs, i));
+      rhs_bits.push_back(getBitShare(rhs, i));
+    }
+    std::vector<NdArrayRef> tmp_out;
+    vmap(lhs_bits.begin(), lhs_bits.end(), rhs_bits.begin(), rhs_bits.end(),
+         std::back_inserter(tmp_out), xor_lambda);
+    for (size_t i = 0; i < common_nbits; ++i) {
+      auto out_i = getBitShare(out, i);
+      ring_assign(out_i, tmp_out[i]);
+    }
+    // calculate the rest bits
+    for (size_t i = common_nbits; i < out_nbits; ++i) {
+      auto more_bit_share =
+          l_nbits > r_nbits ? getBitShare(lhs, i) : getBitShare(rhs, i);
+      auto out_i = getBitShare(out, i);
+      ring_assign(out_i, more_bit_share);
+    }
+  });
+  return out;
+}
+
+NdArrayRef LShiftB::proc(KernelEvalContext* ctx, const NdArrayRef& in,
+                         const Sizes& bits) const {
+  // Fixme
+  SPU_ENFORCE(bits.size() == 1);
+  if (bits[0] == 0) {
+    return in;
+  }
+  const auto* in_ty = in.eltype().as<BShrTy>();
+  const auto b_field = in_ty->field();
+  const auto field = ctx->getState<Z2kState>()->getDefaultField();
+  const size_t out_nbits = std::min<size_t>(
+      in_ty->nbits() + *std::max_element(bits.begin(), bits.end()),
+      GetMersennePrimeExp(field));
+
+  auto out_ty = makeType<BShrTy>(b_field, out_nbits);
+  NdArrayRef out(out_ty, in.shape());
+  memset(out.data(), 0, out.numel() * out.elsize());
+  auto shift = bits[0];
+  // FIXME: optimize me, all the following things are memory copies
+  for (int64_t idx = 0; idx < static_cast<int64_t>(out_nbits) - shift; ++idx) {
+    auto in_i = getBitShare(in, idx);
+    auto out_i = getBitShare(out, idx + shift);
+    ring_assign(out_i, in_i);
+  }
+  return out;
+}
+
+NdArrayRef RShiftB::proc(KernelEvalContext*, const NdArrayRef& in,
+                         const Sizes& bits) const {
+  // Fixme
+  SPU_ENFORCE(bits.size() == 1);
+  if (bits[0] == 0) {
+    return in;
+  }
+  const auto* in_ty = in.eltype().as<BShrTy>();
+  int64_t out_nbits = in_ty->nbits();
+  out_nbits -= std::min(out_nbits, *std::min_element(bits.begin(), bits.end()));
+  const auto b_field = in_ty->field();
+
+  auto out_ty = makeType<BShrTy>(b_field, out_nbits);
+  NdArrayRef out(out_ty, in.shape());
+  auto shift = bits[0];
+  // FIXME: optimize me, all the following things are memory copies
+  for (int64_t idx = 0; idx < static_cast<int64_t>(out_nbits); ++idx) {
+    auto in_i = getBitShare(in, idx + shift);
+    auto out_i = getBitShare(out, idx);
+    ring_assign(out_i, in_i);
+  }
+  return out;
+}
+
+NdArrayRef ARShiftB::proc(KernelEvalContext* ctx, const NdArrayRef& in,
+                          const Sizes& bits) const {
+  // Fixme
+  SPU_ENFORCE(bits.size() == 1);
+  if (bits[0] == 0) {
+    return in;
+  }
+
+  const auto field = ctx->getState<Z2kState>()->getDefaultField();
+  const auto* in_ty = in.eltype().as<BShrTy>();
+
+  // assume the nbits should not be greater than field bits
+  SPU_ENFORCE(in_ty->nbits() <= GetMersennePrimeExp(field),
+              "in.type={}, field={}", in.eltype(), field);
+  const int64_t out_nbits = in_ty->nbits();
+  const auto b_field = in_ty->field();
+
+  auto out_ty = makeType<BShrTy>(b_field, out_nbits);
+  NdArrayRef out(out_ty, in.shape());
+  auto shift = bits[0];
+  // FIXME: optimize me, all the following things are memory copies
+  for (int64_t idx = 0; idx < static_cast<int64_t>(out_nbits) - shift; ++idx) {
+    auto in_i = getBitShare(in, idx + shift);
+    auto out_i = getBitShare(out, idx);
+    ring_assign(out_i, in_i);
+  }
+  // fill the rest as msb
+  NdArrayRef msb = getBitShare(in, in_ty->nbits() - 1);
+  if (in_ty->nbits() < GetMersennePrimeExp(field)) {
+    msb = ring_zeros(b_field, in.shape());
+  }
+  for (int64_t idx = static_cast<int64_t>(out_nbits) - shift; idx < out_nbits;
+       ++idx) {
+    auto out_i = getBitShare(out, idx);
+    ring_assign(out_i, msb);
+  }
+  return out;
+}
+
+NdArrayRef BitrevB::proc(KernelEvalContext*, const NdArrayRef& in, size_t start,
+                         size_t end) const {
+  SPU_ENFORCE(start <= end && end <= 128);
+
+  const auto* in_ty = in.eltype().as<BShrTy>();
+  if (start > in_ty->nbits() || start == end) {
+    return in;
+  }
+  const size_t out_nbits = std::max(in_ty->nbits(), end);
+  const auto b_field = in_ty->field();
+  const auto out_ty = makeType<BShrTy>(b_field, out_nbits);
+  NdArrayRef out(out_ty, in.shape());
+  memset(out.data(), 0, out.numel() * out.elsize());
+  for (size_t i = 0; i < start; ++i) {
+    auto src = getBitShare(in, i);
+    auto dst = getBitShare(out, i);
+    ring_assign(dst, src);
+  }
+  for (size_t i = end; i < in_ty->nbits(); ++i) {
+    auto src = getBitShare(in, i);
+    auto dst = getBitShare(out, i);
+    ring_assign(dst, src);
+  }
+  for (size_t i = 0; i + start < end; ++i) {
+    auto src = getBitShare(in, i + start);
+    auto dst = getBitShare(out, end - 1 - i);
+    ring_assign(dst, src);
+  }
+  return out;
+}
+
+NdArrayRef BitIntlB::proc(KernelEvalContext*, const NdArrayRef& in,
+                          size_t stride) const {
+  const auto* in_ty = in.eltype().as<BShrTy>();
+  const size_t nbits = in_ty->nbits();
+  SPU_ENFORCE(absl::has_single_bit(nbits));
+
+  NdArrayRef out(in.eltype(), in.shape());
+  int64_t offset = 1 << stride;
+  int64_t half_bits = nbits / 2;
+  int64_t idx = 0;
+  for (int64_t i = 0; i < half_bits; i += offset) {
+    for (int j = 0; j < offset; ++j) {
+      auto src = getBitShare(in, i + j);
+      auto dst = getBitShare(out, idx++);
+      ring_assign(dst, src);
+    }
+    for (int j = 0; j < offset; ++j) {
+      auto src = getBitShare(in, i + j + half_bits);
+      auto dst = getBitShare(out, idx++);
+      ring_assign(dst, src);
+    }
+  }
+  SPU_ENFORCE_EQ(idx, static_cast<int64_t>(nbits));
+  return out;
+}
+
+NdArrayRef BitDeintlB::proc(KernelEvalContext*, const NdArrayRef& in,
+                            size_t stride) const {
+  const auto* in_ty = in.eltype().as<BShrTy>();
+  const size_t nbits = in_ty->nbits();
+  SPU_ENFORCE(absl::has_single_bit(nbits));
+
+  NdArrayRef out(in.eltype(), in.shape());
+  int64_t offset = 1 << stride;
+  int64_t half_bits = nbits / 2;
+  int64_t idx = 0;
+  while (idx < half_bits) {
+    for (int j = 0; j < offset; ++j) {
+      auto src = getBitShare(in, idx + j);
+      auto dst = getBitShare(out, idx);
+      ring_assign(dst, src);
+    }
+    for (int j = 0; j < offset; ++j) {
+      auto src = getBitShare(in, idx + j);
+      auto dst = getBitShare(out, idx + half_bits);
+      ring_assign(dst, src);
+    }
+    idx += offset;
+  }
+  SPU_ENFORCE_EQ(idx, static_cast<int64_t>(nbits));
+  return out;
+}
+
+}  // namespace spu::mpc::shamir

--- a/src/libspu/mpc/shamir/boolean.h
+++ b/src/libspu/mpc/shamir/boolean.h
@@ -1,0 +1,213 @@
+// Copyright 2024 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "libspu/core/ndarray_ref.h"
+#include "libspu/mpc/kernel.h"
+
+namespace spu::mpc::shamir {
+
+class CommonTypeB : public Kernel {
+ public:
+  static constexpr const char* kBindName() { return "common_type_b"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  void evaluate(KernelEvalContext* ctx) const override;
+};
+
+class CastTypeB : public CastTypeKernel {
+ public:
+  static constexpr const char* kBindName() { return "cast_type_b"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& in,
+                  const Type& to_type) const override;
+};
+
+class B2P : public UnaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "b2p"; }
+
+  // Kind kind() const override { return Kind::Dynamic; }
+
+  ce::CExpr latency() const override { return ce::Const(2); }
+
+  ce::CExpr comm() const override { return ce::K() * 2; }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& in) const override;
+};
+
+class P2B : public UnaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "p2b"; }
+
+  Kind kind() const override { return Kind::Dynamic; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& in) const override;
+};
+
+class B2V : public RevealToKernel {
+ public:
+  static constexpr const char* kBindName() { return "b2v"; }
+
+  // Kind kind() const override { return Kind::Dynamic; }
+
+  ce::CExpr latency() const override {
+    // 1 * send/recv: 1
+    return ce::Const(1);
+  }
+
+  ce::CExpr comm() const override { return ce::K(); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& in,
+                  size_t rank) const override;
+};
+
+class AndBP : public BinaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "and_bp"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& lhs,
+                  const NdArrayRef& rhs) const override;
+};
+
+class AndBB : public BinaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "and_bb"; }
+
+  ce::CExpr latency() const override { return ce::Const(2); }
+
+  ce::CExpr comm() const override {
+    auto nBits = ce::Variable("nBits", "number of bits");
+    return ce::K() * 2 * nBits;
+  }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& lhs,
+                  const NdArrayRef& rhs) const override;
+};
+
+class XorBP : public BinaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "xor_bp"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& lhs,
+                  const NdArrayRef& rhs) const override;
+};
+
+class XorBB : public BinaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "xor_bb"; }
+
+  Kind kind() const override { return Kind::Dynamic; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& lhs,
+                  const NdArrayRef& rhs) const override;
+};
+
+class LShiftB : public ShiftKernel {
+ public:
+  static constexpr const char* kBindName() { return "lshift_b"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& in,
+                  const Sizes& bits) const override;
+};
+
+class RShiftB : public ShiftKernel {
+ public:
+  static constexpr const char* kBindName() { return "rshift_b"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& in,
+                  const Sizes& bits) const override;
+};
+
+class ARShiftB : public ShiftKernel {
+ public:
+  static constexpr const char* kBindName() { return "arshift_b"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& in,
+                  const Sizes& bits) const override;
+};
+
+class BitrevB : public BitrevKernel {
+ public:
+  static constexpr const char* kBindName() { return "bitrev_b"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& in, size_t start,
+                  size_t end) const override;
+};
+
+class BitIntlB : public BitSplitKernel {
+ public:
+  static constexpr const char* kBindName() { return "bitintl_b"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& in,
+                  size_t stride) const override;
+};
+
+class BitDeintlB : public BitSplitKernel {
+ public:
+  static constexpr const char* kBindName() { return "bitdeintl_b"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& in,
+                  size_t stride) const override;
+};
+
+}  // namespace spu::mpc::shamir

--- a/src/libspu/mpc/shamir/conversion.cc
+++ b/src/libspu/mpc/shamir/conversion.cc
@@ -1,0 +1,908 @@
+// Copyright 2024 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "libspu/mpc/shamir/conversion.h"
+
+#include <future>
+
+#include "libspu/core/trace.h"
+#include "libspu/core/vectorize.h"
+#include "libspu/mpc/ab_api.h"
+#include "libspu/mpc/api.h"
+#include "libspu/mpc/common/communicator.h"
+#include "libspu/mpc/common/prg_state.h"
+#include "libspu/mpc/common/pv2k.h"
+#include "libspu/mpc/common/pv_gfmp.h"
+#include "libspu/mpc/shamir/type.h"
+#include "libspu/mpc/shamir/value.h"
+#include "libspu/mpc/utils/gfmp.h"
+#include "libspu/mpc/utils/gfmp_ops.h"
+#include "libspu/mpc/utils/ring_ops.h"
+
+namespace spu::mpc::shamir {
+
+namespace {
+
+inline bool is_secret(const NdArrayRef& in) {
+  return in.eltype().isa<Secret>();
+}
+
+inline bool is_public(const NdArrayRef& in) {
+  return in.eltype().isa<Public>();
+}
+
+// this return value is splat while wrap_make_zeros  are
+// tensors
+NdArrayRef hack_make_p(SPUContext* ctx, uint128_t init, const Shape& shape) {
+  return UnwrapValue(dynDispatch(ctx, "make_p", init, shape));
+}
+
+NdArrayRef wrap_make_zeros(SPUContext* ctx, const Shape& shape) {
+  const auto field = ctx->getField();
+  return ring_zeros(field, shape).as(makeType<PubGfmpTy>(field));
+}
+
+NdArrayRef wrap_arshift_p(SPUContext* ctx, const NdArrayRef& in,
+                          const Sizes& bits) {
+  return UnwrapValue(arshift_p(ctx, WrapValue(in), bits));
+}
+
+NdArrayRef wrap_a2p(SPUContext* ctx, const NdArrayRef& in) {
+  return UnwrapValue(a2p(ctx, WrapValue(in)));
+}
+
+NdArrayRef wrap_mul_p(SPUContext* ctx, const NdArrayRef& x,
+                      const NdArrayRef& y) {
+  return UnwrapValue(mul_aa_p(ctx, WrapValue(x), WrapValue(y)));
+}
+
+NdArrayRef wrap_mul_aaa(SPUContext* ctx, const NdArrayRef& x, const NdArrayRef& y, const NdArrayRef& z) {
+  return UnwrapValue(mul_aaa(ctx, WrapValue(x), WrapValue(y), WrapValue(z)));
+}
+
+NdArrayRef wrap_mul(SPUContext* ctx, const NdArrayRef& x, const NdArrayRef& y) {
+  if (is_public(x) && is_public(y)) {
+    return UnwrapValue(mul_pp(ctx, WrapValue(x), WrapValue(y)));
+  } else if (is_secret(x) && is_public(y)) {
+    return UnwrapValue(mul_ap(ctx, WrapValue(x), WrapValue(y)));
+  } else if (is_secret(y) && is_public(x)) {
+    return UnwrapValue(mul_ap(ctx, WrapValue(y), WrapValue(x)));
+  } else if (is_secret(x) && is_secret(y)) {
+    return UnwrapValue(mul_aa(ctx, WrapValue(x), WrapValue(y)));
+  }
+  SPU_THROW("should not reach, x={}, y={}", x.eltype(), y.eltype());
+}
+
+NdArrayRef wrap_add(SPUContext* ctx, const NdArrayRef& x, const NdArrayRef& y) {
+  if (is_public(x) && is_public(y)) {
+    return UnwrapValue(add_pp(ctx, WrapValue(x), WrapValue(y)));
+  } else if (is_secret(x) && is_public(y)) {
+    return UnwrapValue(add_ap(ctx, WrapValue(x), WrapValue(y)));
+  } else if (is_secret(y) && is_public(x)) {
+    return UnwrapValue(add_ap(ctx, WrapValue(y), WrapValue(x)));
+  } else if (is_secret(x) && is_secret(y)) {
+    return UnwrapValue(add_aa(ctx, WrapValue(x), WrapValue(y)));
+  }
+  SPU_THROW("should not reach");
+}
+
+NdArrayRef wrap_negate(SPUContext* ctx, const NdArrayRef& x) {
+  if (is_public(x)) {
+    return UnwrapValue(negate_p(ctx, WrapValue(x)));
+  } else if (is_secret(x)) {
+    return UnwrapValue(negate_a(ctx, WrapValue(x)));
+  }
+  SPU_THROW("should not reach");
+}
+
+NdArrayRef wrap_sub(SPUContext* ctx, const NdArrayRef& x, const NdArrayRef& y) {
+  return wrap_add(ctx, x, wrap_negate(ctx, y));
+}
+
+NdArrayRef wrap_rand_a(SPUContext* ctx, const Shape& shape) {
+  return UnwrapValue(rand_a(ctx, shape));
+}
+
+// x ^ y = (x + y) - 2 * (x * y) for x,y in [0,1]
+NdArrayRef wrap_xor(SPUContext* ctx, const NdArrayRef& x, const NdArrayRef& y) {
+  auto k2 = hack_make_p(ctx, 2, x.shape());
+  auto x_mul_y = wrap_mul(ctx, x, y);
+  auto x_add_y = wrap_add(ctx, x, y);
+  auto k2xy = wrap_mul(ctx, x_mul_y, k2);
+  auto out = wrap_sub(ctx, x_add_y, k2xy);
+  return out;
+}
+
+// [Offline Phase]
+std::pair<std::vector<NdArrayRef>, std::vector<NdArrayRef>>
+gen_prefix_mult_share(SPUContext* ctx, const int64_t numel,
+                      const int64_t num_prefix) {
+  // let k denote num_prefix
+  const auto field = ctx->getState<Z2kState>()->getDefaultField();
+  auto ty = makeType<PubGfmpTy>(field);
+
+  auto mul_lambda = [ctx](const NdArrayRef& a, const NdArrayRef& b) {
+    return wrap_mul(ctx, a, b);
+  };
+  auto mul_p_lambda = [ctx](const NdArrayRef& a, const NdArrayRef& b) {
+    return wrap_mul_p(ctx, a, b);
+  };
+
+  NdArrayRef rand_raw = wrap_rand_a(ctx, {(num_prefix << 1) * numel});
+
+  // for each instance, generate r_1 ..., r_k and s_1 ..., s_k
+  std::vector<NdArrayRef> rand_r;
+  std::vector<NdArrayRef> rand_s;
+
+  int64_t offset = num_prefix * numel;
+
+  for (int64_t i = 0; i < num_prefix; ++i) {
+    rand_r.push_back(
+        rand_raw.slice({i * numel}, {(i + 1) * numel}, {}).reshape({numel}));
+    rand_s.push_back(
+        rand_raw.slice({offset + i * numel}, {offset + (i + 1) * numel}, {})
+            .reshape({numel}));
+  }
+
+  std::vector<NdArrayRef> rand_prod;
+  std::vector<NdArrayRef> rand_prod_offset;
+  // TODO: The following two multiplications (mul and mul_p) can be run in
+  // parallel. rand_prod is of length num_prefix storing B_i = r_i * s_i
+  vmap(rand_r.cbegin(), rand_r.cend(), rand_s.cbegin(), rand_s.cend(),
+       std::back_inserter(rand_prod), mul_p_lambda);
+
+  // rand_prod_offset is of length num_prefix - 1 storing C_0 = s_0 and C_i =
+  // r_i * s_{i+1} for i > 1
+  rand_prod_offset.push_back(rand_s[0]);
+  vmap(rand_r.cbegin(), rand_r.cend() - 1, rand_s.cbegin() + 1, rand_s.cend(),
+       std::back_inserter(rand_prod_offset), mul_lambda);
+
+  auto p_rand_prod = rand_prod[0];
+  // rand_prod is of length num_prefix storing B_i^-1 = (r_i * s_i)^{-1}
+  std::vector<NdArrayRef> rand_prod_inv;
+  for (int64_t i = 0; i < num_prefix; ++i) {
+    rand_prod_inv.push_back(gfmp_batch_inverse(rand_prod[i]));
+  }
+
+  // An unbounded multiplication instance
+  // ( [r0]_t , [r0^-1]_t )
+  // ( [r1]_t , [r1 * r2^-1]_t,)
+  // ( [r2]_t , [r2 * r3^-1]_t)
+  // ...
+  // ( [ri]_t , [ri-1 * ri^-1]_t) for i = 2, ..., k
+  std::vector<NdArrayRef> rand_r_aux;
+  vmap(rand_prod_inv.cbegin(), rand_prod_inv.cend(), rand_prod_offset.cbegin(),
+       rand_prod_offset.cend(), std::back_inserter(rand_r_aux), mul_lambda);
+
+  std::pair<std::vector<NdArrayRef>, std::vector<NdArrayRef>> out;
+  out.first = std::move(rand_r);
+  out.second = std::move(rand_r_aux);
+  return out;
+}
+
+// Generate zero sharings of degree = threshold
+// [Offline Phase]
+NdArrayRef gen_zero_shares(KernelEvalContext* ctx, int64_t numel,
+                           int64_t threshold) {
+  const auto field = ctx->getState<Z2kState>()->getDefaultField();
+  auto* prg_state = ctx->getState<PrgState>();
+  auto* comm = ctx->getState<Communicator>();
+  auto ty = makeType<PubGfmpTy>(field);
+  auto r = prg_state->genPubl(field, {threshold * numel}).as(ty);
+  auto coeffs = gfmp_mod(r);
+  NdArrayRef zeros = ring_zeros(field, {numel}).as(makeType<GfmpTy>(field));
+  auto shares =
+      gfmp_rand_shamir_shares(zeros, coeffs, comm->getWorldSize(), threshold);
+  return shares[comm->getRank()].as(makeType<AShrTy>(field));
+}
+// Ref: https://iacr.org/archive/tcc2006/38760286/38760286.pdf
+//  Page 11: Protocol RAN2
+// [Offline Phase]
+NdArrayRef rand_bits(SPUContext* ctx, int64_t numel) {
+  const auto field = ctx->getState<Z2kState>()->getDefaultField();
+  NdArrayRef out(makeType<AShrTy>(field), {numel});
+  std::vector<int64_t> cur_failed_indices;
+  std::vector<int64_t> pre_failed_indices;
+  std::mutex idx_mtx;
+
+  // TODO: To minimize round complexity, another method to handling rand_a = 0
+  // is sampling redundantly, which means that we can sample (1 + \epsilon) *
+  // `numel` elements.
+  auto rand_a = wrap_rand_a(ctx, {numel});
+  auto rand_a_square_p = wrap_mul_p(ctx, rand_a, rand_a);
+  NdArrayRef rand_sqrt(out.eltype(), out.shape());
+
+  DISPATCH_ALL_FIELDS(field, [&]() {
+    NdArrayView<ring2k_t> _rand_a(rand_a);
+    NdArrayView<ring2k_t> _rand_a_square_p(rand_a_square_p);
+    NdArrayView<ring2k_t> _rand_sqrt(rand_sqrt);
+    int64_t num_failed = 0;
+    pforeach(0, numel, [&](int64_t idx) {
+      if (_rand_a_square_p[idx] == 0) {
+        num_failed++;
+      } else {
+        _rand_sqrt[idx] = sqrt_mod(_rand_a_square_p[idx]);
+      }
+    });
+    SPU_ENFORCE_EQ(num_failed, 0);
+  });
+  NdArrayRef rand_sqrt_inverse = gfmp_batch_inverse(rand_sqrt);
+  DISPATCH_ALL_FIELDS(field, [&]() {
+    NdArrayView<ring2k_t> _rand_a(rand_a);
+    NdArrayView<ring2k_t> _rand_sqrt_inverse(rand_sqrt_inverse);
+    NdArrayView<ring2k_t> _out(out);
+    const ring2k_t inverse_two = mul_inv(static_cast<ring2k_t>(2));
+    pforeach(0, numel, [&](int64_t idx) {
+      auto c = mul_mod(_rand_a[idx], _rand_sqrt_inverse[idx]);
+      _out[idx] = mul_mod(inverse_two, add_mod(c, static_cast<ring2k_t>(1)));
+    });
+  });
+  return out;
+}
+
+// Ref: https://iacr.org/archive/tcc2006/38760286/38760286.pdf
+//  Unbounded Fan-In Multiplication
+std::vector<NdArrayRef> prefix_mul(SPUContext* ctx,
+                                   const std::vector<NdArrayRef>& inputs) {
+  SPU_ENFORCE(!inputs.empty());
+  int64_t l = inputs.size();
+  auto numel = inputs[0].numel();
+  auto mul_p_lambda = [ctx](const NdArrayRef& a, const NdArrayRef& b) {
+    return wrap_mul_p(ctx, a, b);
+  };
+  auto mul_lambda = [ctx](const NdArrayRef& a, const NdArrayRef& b) {
+    return wrap_mul(ctx, a, b);
+  };
+
+  auto randomness = gen_prefix_mult_share(ctx, numel, l);
+  auto r = randomness.first;
+  auto r_aux = randomness.second;
+
+  std::vector<NdArrayRef> out;
+  vmap(inputs.cbegin(), inputs.cend(), r_aux.cbegin(), r_aux.cend(),
+       std::back_inserter(out), mul_p_lambda);
+  for (int64_t i = 1; i < l; ++i) {
+    out[i] = wrap_mul(ctx, out[i], out[i - 1]);
+  }
+  vmap(out.cbegin(), out.cend(), r.cbegin(), r.cend(), out.begin(), mul_lambda);
+
+  return out;
+}
+
+// Ref:
+// https://www.usenix.org/system/files/sec24summer-prepub-278-liu-fengrun.pdf
+//  Protocol 4.1: Prefix Or
+std::vector<NdArrayRef> prefix_or(SPUContext* ctx,
+                                  const std::vector<NdArrayRef>& inputs) {
+  SPU_ENFORCE(!inputs.empty());
+  std::vector<NdArrayRef> b(inputs.size());
+  const auto k1 = hack_make_p(ctx, 1, inputs[0].shape());
+  for (size_t i = 0; i < inputs.size(); ++i) {
+    b[i] = wrap_sub(ctx, k1, inputs[i]);
+  }
+  auto c = prefix_mul(ctx, b);
+  for (size_t i = 0; i < inputs.size(); ++i) {
+    c[i] = wrap_sub(ctx, k1, c[i]);
+  }
+  return c;
+}
+
+// Ref:
+// https://www.usenix.org/system/files/sec24summer-prepub-278-liu-fengrun.pdf
+//  Protocol 4.2: Optimized bitwise less-than for public a and secret b
+NdArrayRef bit_lt_ap(SPUContext* ctx, const std::vector<NdArrayRef>& a,
+                     const std::vector<NdArrayRef>& b) {
+  SPU_ENFORCE(!a.empty());
+  SPU_ENFORCE_EQ(a.size(), b.size());
+  SPU_ENFORCE(std::all_of(a.begin(), a.end(),
+                          [](const NdArrayRef& x) { return is_public(x); }));
+  SPU_ENFORCE(std::all_of(b.begin(), b.end(),
+                          [](const NdArrayRef& x) { return is_secret(x); }));
+  std::vector<NdArrayRef> c;
+  std::vector<NdArrayRef> inv_a(a.size());
+  {
+    const auto k1 = hack_make_p(ctx, 1, a[0].shape());
+    std::vector<NdArrayRef> inv_b(a.size());
+    auto xor_lambda = [ctx](const NdArrayRef& a, const NdArrayRef& b) {
+      return wrap_xor(ctx, a, b);
+    };
+    for (size_t i = 0; i < a.size(); ++i) {
+      inv_a[i] = wrap_sub(ctx, k1, a[i]);
+      inv_b[i] = wrap_sub(ctx, k1, b[i]);
+    }
+    vmap(inv_a.begin(), inv_a.end(), inv_b.begin(), inv_b.end(),
+         std::back_inserter(c), xor_lambda);
+  }
+  std::vector<NdArrayRef> h;
+  {
+    std::reverse(c.begin(), c.end());
+    auto d = prefix_or(ctx, c);
+    std::reverse(d.begin(), d.end());
+
+    std::vector<NdArrayRef> e(a.size());
+    e.back() = d.back();
+    for (size_t i = 0; i < e.size() - 1; ++i) {
+      e[i] = wrap_sub(ctx, d[i], d[i + 1]);
+    }
+
+    auto mul_lambda = [ctx](const NdArrayRef& a, const NdArrayRef& b) {
+      return wrap_mul(ctx, a, b);
+    };
+    vmap(inv_a.begin(), inv_a.end(), e.begin(), e.end(), std::back_inserter(h),
+         mul_lambda);
+  }
+
+  NdArrayRef out = wrap_make_zeros(ctx, a[0].shape());
+  for (size_t i = 0; i < h.size(); ++i) {
+    out = wrap_add(ctx, out, h[i]);
+  }
+  return out;
+}
+
+// Ref: https://iacr.org/archive/tcc2006/38760286/38760286.pdf
+//  5.3: Generic bitwise less-than
+NdArrayRef bit_lt(SPUContext* ctx, const std::vector<NdArrayRef>& a,
+                  const std::vector<NdArrayRef>& b) {
+  SPU_ENFORCE(!a.empty());
+  SPU_ENFORCE_EQ(a.size(), b.size());
+  std::vector<NdArrayRef> e;
+
+  auto xor_lambda = [ctx](const NdArrayRef& a, const NdArrayRef& b) {
+    return wrap_xor(ctx, a, b);
+  };
+
+  vmap(a.begin(), a.end(), b.begin(), b.end(), std::back_inserter(e),
+       xor_lambda);
+
+  std::reverse(e.begin(), e.end());
+  auto f = prefix_or(ctx, e);
+
+  std::reverse(f.begin(), f.end());
+  std::vector<NdArrayRef> g(f.size());
+  g.back() = f.back();
+  for (size_t i = 0; i < f.size() - 1; ++i) {
+    g[i] = wrap_sub(ctx, f[i], f[i + 1]);
+  }
+
+  std::vector<NdArrayRef> h;
+  auto mul_lambda = [ctx](const NdArrayRef& a, const NdArrayRef& b) {
+    return wrap_mul(ctx, a, b);
+  };
+  vmap(g.cbegin(), g.cend(), b.begin(), b.end(), std::back_inserter(h),
+       mul_lambda);
+
+  NdArrayRef out = wrap_make_zeros(ctx, a[0].shape());
+  for (size_t i = 0; i < h.size(); ++i) {
+    out = wrap_add(ctx, out, h[i]);
+  }
+
+  return out;
+}
+
+using Triple = std::tuple<NdArrayRef, NdArrayRef, NdArrayRef>;
+
+// Ref: https://iacr.org/archive/tcc2006/38760286/38760286.pdf
+//  6.4: Unbounded fan-in carry propagation
+Triple unbounded_carries(SPUContext* ctx, const std::vector<NdArrayRef>& s,
+                         const std::vector<NdArrayRef>& p,
+                         const std::vector<NdArrayRef>& k) {
+  SPU_ENFORCE(!s.empty());
+  SPU_ENFORCE_EQ(s.size(), p.size());
+  SPU_ENFORCE_EQ(k.size(), p.size());
+  NdArrayRef a;
+
+  auto p_copy = p;
+  std::reverse(p_copy.begin(), p_copy.end());
+  std::vector<NdArrayRef> q = prefix_mul(ctx, p_copy);
+  NdArrayRef b = q[q.size() - 1];
+  NdArrayRef c = wrap_make_zeros(ctx, s[0].shape());
+  {
+    std::reverse(q.begin(), q.end());
+    auto mul_lambda = [ctx](const NdArrayRef& a, const NdArrayRef& b) {
+      return wrap_mul(ctx, a, b);
+    };
+    std::vector<NdArrayRef> c_vec;
+    vmap(k.begin(), k.end() - 1, q.cbegin() + 1, q.cend(),
+         std::back_inserter(c_vec), mul_lambda);
+    c_vec.push_back(k.back());
+    for (size_t i = 0; i < c_vec.size(); ++i) {
+      c = wrap_add(ctx, c, c_vec[i]);
+    }
+    auto k1 = hack_make_p(ctx, 1, s[0].shape());
+    a = wrap_sub(ctx, k1, wrap_add(ctx, b, c));
+  }
+  Triple out;
+  std::get<0>(out) = std::move(a);
+  std::get<1>(out) = std::move(b);
+  std::get<2>(out) = std::move(c);
+  return out;
+}
+
+// Ref: https://iacr.org/archive/tcc2006/38760286/38760286.pdf
+//  6.1: Generic prefix computations for carry propagation
+// Todo: Optimize this function using the CFL algorithm
+//  Ref: https://dl.acm.org/doi/pdf/10.1145/800061.808732
+std::vector<Triple> prefix_carries(SPUContext* ctx,
+                                   const std::vector<NdArrayRef>& s,
+                                   const std::vector<NdArrayRef>& p,
+                                   const std::vector<NdArrayRef>& k) {
+  SPU_ENFORCE(!s.empty());
+  SPU_ENFORCE_EQ(s.size(), p.size());
+  SPU_ENFORCE_EQ(k.size(), p.size());
+  std::vector<Triple> out(s.size());
+  out[0] = {s[0], p[0], k[0]};
+
+  std::vector<std::future<Triple>> futures;
+  std::vector<std::unique_ptr<SPUContext>> sub_ctxs;
+  for (size_t i = 1; i < s.size(); ++i) {
+    sub_ctxs.push_back(ctx->fork());
+  }
+  for (size_t i = 1; i < s.size(); ++i) {
+    auto tmp_s = std::vector<NdArrayRef>(s.begin(), s.begin() + i + 1);
+    auto tmp_p = std::vector<NdArrayRef>(p.begin(), p.begin() + i + 1);
+    auto tmp_k = std::vector<NdArrayRef>(k.begin(), k.begin() + i + 1);
+    auto async_res = std::async(unbounded_carries, sub_ctxs[i - 1].get(), tmp_s,
+                                tmp_p, tmp_k);
+    futures.push_back(std::move(async_res));
+  }
+  for (size_t i = 1; i < s.size(); ++i) {
+    out[i] = futures[i - 1].get();
+  }
+
+  return out;
+}
+
+// Ref: https://iacr.org/archive/tcc2006/38760286/38760286.pdf
+//  6.3: Carries
+std::vector<NdArrayRef> carries(SPUContext* ctx,
+                                const std::vector<NdArrayRef>& a,
+                                const std::vector<NdArrayRef>& b) {
+  SPU_ENFORCE(!a.empty());
+  SPU_ENFORCE_EQ(a.size(), b.size());
+
+  auto mul_lambda = [ctx](const NdArrayRef& a, const NdArrayRef& b) {
+    return wrap_mul(ctx, a, b);
+  };
+
+  std::vector<NdArrayRef> s;
+  // S[i] = A[i] * B[i]
+  vmap(a.begin(), a.end(), b.begin(), b.end(), std::back_inserter(s),
+       mul_lambda);
+
+  std::vector<NdArrayRef> p(a.size());
+  std::vector<NdArrayRef> k(a.size());
+  std::vector<NdArrayRef> c(a.size());
+  const auto k2 = hack_make_p(ctx, 2, a[0].shape());
+  const auto k1 = hack_make_p(ctx, 1, a[0].shape());
+  for (size_t i = 0; i < a.size(); ++i) {
+    // P[i] = A[i] + B[i] - 2 * S[i]
+    p[i] = wrap_sub(ctx, wrap_add(ctx, a[i], b[i]), wrap_mul(ctx, k2, s[i]));
+    // K[i] = 1 - S[i] - P[i]
+    k[i] = wrap_sub(ctx, k1, wrap_add(ctx, s[i], p[i]));
+  }
+  auto f = prefix_carries(ctx, s, p, k);
+  for (size_t i = 0; i < a.size(); ++i) {
+    c[i] = std::move(std::get<0>(f[i]));
+  }
+
+  return c;
+}
+
+// Ref: https://iacr.org/archive/tcc2006/38760286/38760286.pdf
+//  6.2: Bitwise sum
+std::vector<NdArrayRef> bit_add(SPUContext* ctx,
+                                const std::vector<NdArrayRef>& a,
+                                const std::vector<NdArrayRef>& b) {
+  SPU_ENFORCE(!a.empty());
+  SPU_ENFORCE_EQ(a.size(), b.size());
+  auto c = carries(ctx, a, b);
+
+  std::vector<NdArrayRef> d(a.size() + 1);
+  const auto k2 = hack_make_p(ctx, 2, a[0].shape());
+  // D[0] = A[0] + B[0] - 2 * C[0]
+  d[0] = wrap_sub(ctx, wrap_add(ctx, a[0], b[0]), wrap_mul(ctx, k2, c[0]));
+  // D[l] = C[l-1]
+  d[a.size()] = c[a.size() - 1];
+  // D[i] = A[i] + B[i] + C[i-1] - 2 * C[i]
+  for (size_t i = 1; i < a.size(); ++i) {
+    d[i] = wrap_sub(ctx, wrap_add(ctx, wrap_add(ctx, a[i], b[i]), c[i - 1]),
+                    wrap_mul(ctx, k2, c[i]));
+  }
+
+  return d;
+}
+
+// Ref: https://iacr.org/archive/tcc2006/38760286/38760286.pdf
+//  Page 3.1: Solved bits
+// [Offline Phase]
+std::pair<std::vector<NdArrayRef>, NdArrayRef> solved_bits(SPUContext* ctx,
+                                                           const Shape& shape) {
+  const auto field = ctx->getState<Z2kState>()->getDefaultField();
+  std::vector<int64_t> cur_failed_indices;
+  std::vector<int64_t> pre_failed_indices;
+  std::mutex idx_mtx;
+  int64_t produced = 0;
+  int64_t numel = shape.numel();
+  int64_t un_produced = numel;
+
+  return DISPATCH_ALL_FIELDS(field, [&]() {
+    size_t exp = ScalarTypeToPrime<ring2k_t>::exp;
+    std::vector<NdArrayRef> out_bits(exp);
+    NdArrayRef out = wrap_make_zeros(ctx, shape).as(makeType<AShrTy>(field));
+    auto randbits = rand_bits(ctx, numel * exp);
+    for (int64_t i = 0; i < static_cast<int64_t>(exp); ++i) {
+      out_bits[i] =
+          randbits.slice({i * numel}, {(i + 1) * numel}, {}).reshape(shape);
+    }
+
+    std::vector<ring2k_t> bits_coeff(exp);
+    for (size_t i = 0; i < exp; ++i) {
+      bits_coeff[i] = static_cast<ring2k_t>(1) << i;
+    }
+
+    NdArrayView<ring2k_t> _out(out);
+    pforeach(0, numel, [&](int64_t idx) {
+      for (size_t i = 0; i < exp; ++i) {
+        NdArrayView<ring2k_t> _out_i(out_bits[i]);
+        _out[idx] = add_mod(
+            _out[idx], mul_mod(static_cast<ring2k_t>(1) << i, _out_i[idx]));
+      }
+    });
+
+    std::pair<std::vector<NdArrayRef>, NdArrayRef> ret;
+    ret.first = std::move(out_bits);
+    ret.second = std::move(out);
+    return ret;
+  });
+
+  return DISPATCH_ALL_FIELDS(field, [&]() {
+    size_t exp = ScalarTypeToPrime<ring2k_t>::exp;
+    std::vector<NdArrayRef> out_bits(exp);
+    NdArrayRef out = wrap_make_zeros(ctx, shape).as(makeType<AShrTy>(field));
+
+    auto k1 = hack_make_p(ctx, 1, shape);
+    std::vector<NdArrayRef> tmp_p_bits(exp, k1);
+    while (un_produced > 0) {
+      std::vector<NdArrayRef> tmp_out(exp);
+      auto randbits = rand_bits(ctx, numel * exp);
+      for (int64_t i = 0; i < static_cast<int64_t>(exp); ++i) {
+        tmp_out[i] =
+            randbits.slice({i * numel}, {(i + 1) * numel}, {}).reshape(shape);
+      }
+      auto cmp = bit_lt(ctx, tmp_out, tmp_p_bits);
+      auto cmp_p = wrap_a2p(ctx, cmp);
+      NdArrayView<ring2k_t> _cmp_p(cmp);
+      pforeach(0, un_produced, [&](int64_t idx) {
+        if (_cmp_p[idx] == 0) {
+          std::unique_lock lock(idx_mtx);
+          cur_failed_indices.push_back(idx);
+        }
+      });
+      NdArrayView<ring2k_t> _out(out);
+      if (pre_failed_indices.empty()) {
+        for (size_t i = 0; i < exp; ++i) {
+          out_bits[i] = tmp_out[i];
+        }
+        pforeach(0, un_produced, [&](int64_t idx) {
+          for (size_t i = 0; i < exp; ++i) {
+            NdArrayView<ring2k_t> _tmp_out_i(tmp_out[i]);
+            _out[idx] = add_mod(
+                _out[idx],
+                mul_mod(static_cast<ring2k_t>(1) << i, _tmp_out_i[idx]));
+          }
+        });
+      } else {
+        pforeach(0, un_produced, [&](int64_t idx) {
+          _out[pre_failed_indices[idx]] = 0;
+          for (size_t i = 0; i < exp; ++i) {
+            NdArrayView<ring2k_t> _tmp_out_i(tmp_out[i]);
+            _out[pre_failed_indices[idx]] = add_mod(
+                _out[pre_failed_indices[idx]],
+                mul_mod(static_cast<ring2k_t>(1) << i, _tmp_out_i[idx]));
+            ;
+          }
+        });
+      }
+      un_produced = cur_failed_indices.size();
+      produced = numel - un_produced;
+      pre_failed_indices = cur_failed_indices;
+      cur_failed_indices.clear();
+    }
+    std::pair<std::vector<NdArrayRef>, NdArrayRef> ret;
+    ret.first = std::move(out_bits);
+    ret.second = std::move(out);
+    return ret;
+  });
+}
+
+std::vector<NdArrayRef> bit_decompose(SPUContext* ctx, const NdArrayRef& in) {
+  auto numel = in.numel();
+  auto field = in.eltype().as<GfmpTy>()->field();
+
+  return DISPATCH_ALL_FIELDS(field, [&]() {
+    size_t exp = ScalarTypeToPrime<ring2k_t>::exp;
+    std::vector<NdArrayRef> out;
+    for (size_t bit = 0; bit < exp; bit++) {
+      out.push_back(
+          wrap_make_zeros(ctx, in.shape()).as(makeType<PubGfmpTy>(field)));
+    }
+    NdArrayView<ring2k_t> _in(in);
+    pforeach(0, numel, [&](int64_t idx) {
+      const auto& v = _in[idx];
+      for (size_t bit = 0; bit < exp; bit++) {
+        NdArrayView<ring2k_t> _out(out[bit]);
+        _out[idx] = (static_cast<ring2k_t>(v) >> bit) & 0x1;
+      }
+    });
+    return out;
+  });
+}
+
+}  // namespace
+
+using Bits = std::vector<NdArrayRef>;
+// Ref: https://iacr.org/archive/tcc2006/38760286/38760286.pdf
+//  Page 9: Protocol BITS
+NdArrayRef A2B::proc(KernelEvalContext* ctx, const NdArrayRef& x) const {
+  const auto field = x.eltype().as<Ring2k>()->field();
+  auto* sctx = ctx->sctx();
+  std::vector<NdArrayRef> b_bits;
+  NdArrayRef b;
+  std::tie(b_bits, b) = solved_bits(sctx, x.shape());
+  auto a_minus_b = wrap_sub(sctx, x, b);
+  auto c = wrap_a2p(sctx, a_minus_b);
+  auto c_bits = bit_decompose(sctx, c);
+  const auto k1 = hack_make_p(sctx, 1, x.shape());
+  auto c_plus_one = wrap_add(sctx, c, k1);
+  auto c_plus_one_bits = bit_decompose(sctx, c_plus_one);
+
+  std::vector<std::future<Bits>> futures;
+  std::vector<std::unique_ptr<SPUContext>> sub_ctxs;
+  for (size_t i = 0; i < 2; ++i) {
+    sub_ctxs.push_back(sctx->fork());
+  }
+
+  auto async_res0 = std::async(bit_add, sub_ctxs[0].get(), c_bits, b_bits);
+  futures.push_back(std::move(async_res0));
+  auto async_res1 =
+      std::async(bit_add, sub_ctxs[1].get(), c_plus_one_bits, b_bits);
+  futures.push_back(std::move(async_res1));
+
+  auto c1 = futures[0].get();
+  auto c2 = futures[1].get();
+
+  NdArrayRef s = c1.back();
+
+  auto sub_lambda = [sctx](const NdArrayRef& a, const NdArrayRef& b) {
+    return wrap_sub(sctx, a, b);
+  };
+  auto add_lambda = [sctx](const NdArrayRef& a, const NdArrayRef& b) {
+    return wrap_add(sctx, a, b);
+  };
+  auto mul_lambda = [sctx](const NdArrayRef& a, const NdArrayRef& b) {
+    return wrap_mul(sctx, a, b);
+  };
+  std::vector<NdArrayRef> c_delta;
+  vmap(c2.cbegin(), c2.cend() - 1, c1.cbegin(), c1.cend() - 1,
+       std::back_inserter(c_delta), sub_lambda);
+
+  std::vector<NdArrayRef> s_bits(c_delta.size(), s);
+  std::vector<NdArrayRef> prod;
+  vmap(s_bits.cbegin(), s_bits.cend(), c_delta.cbegin(), c_delta.cend(),
+       std::back_inserter(prod), mul_lambda);
+
+  std::vector<NdArrayRef> x_bits;
+  vmap(c1.cbegin(), c1.cend() - 1, prod.cbegin(), prod.cend(),
+       std::back_inserter(x_bits), add_lambda);
+
+  NdArrayRef out(makeType<BShrTy>(field, prod.size()), x.shape());
+  // vmap()
+  for (size_t i = 0; i < x_bits.size(); ++i) {
+    auto out_i = getBitShare(out, i);
+    ring_assign(out_i, x_bits[i]);
+  }
+  return out;
+}
+
+NdArrayRef B2A::proc(KernelEvalContext* ctx, const NdArrayRef& x) const {
+  const auto* ty = x.eltype().as<BShrTy>();
+  const auto field = ty->field();
+  const auto nbits = ty->nbits();
+
+  auto out = wrap_make_zeros(ctx->sctx(), x.shape());
+  DISPATCH_ALL_FIELDS(field, [&]() {
+    for (size_t i = 0; i < nbits; ++i) {
+      auto bit_i = getBitShare(x, i);
+      NdArrayView<ring2k_t> _bit_i(bit_i);
+      NdArrayView<ring2k_t> _out(out);
+      pforeach(0, x.numel(), [&](int64_t idx) {
+        _out[idx] = add_mod(
+            _out[idx], mul_mod(static_cast<ring2k_t>(1) << i, _bit_i[idx]));
+      });
+    }
+  });
+  return out.as(makeType<AShrTy>(field));
+}
+
+// Ref:
+// https://www.usenix.org/system/files/sec24summer-prepub-278-liu-fengrun.pdf
+// Protocol 3.1: Truncation
+NdArrayRef TruncA::proc(KernelEvalContext* ctx, const NdArrayRef& x,
+                        size_t bits, SignType sign) const {
+  (void)sign;  // TODO: optimize me.
+
+  const auto field = x.eltype().as<GfmpTy>()->field();
+  auto* sctx = ctx->sctx();
+  std::vector<NdArrayRef> r_bits;
+  NdArrayRef r;
+  std::tie(r_bits, r) = solved_bits(sctx, x.shape());
+  auto r_msb = r_bits.back();
+  return DISPATCH_ALL_FIELDS(field, [&]() {
+    auto l = ScalarTypeToPrime<ring2k_t>::exp;
+    SPU_ENFORCE_LT(bits, l);
+    NdArrayRef r_hat = wrap_make_zeros(sctx, x.shape());
+    for (size_t i = bits; i < l; ++i) {
+      auto k =
+          hack_make_p(sctx, static_cast<uint128_t>(1) << (i - bits), x.shape());
+      r_hat = wrap_add(sctx, r_hat, wrap_mul(sctx, k, r_bits[i]));
+    }
+    for (size_t i = l - bits; i < l; ++i) {
+      auto k = hack_make_p(sctx, static_cast<uint128_t>(1) << i, x.shape());
+      r_hat = wrap_add(sctx, r_hat, wrap_mul(sctx, k, r_msb));
+    }
+    // k2 = 2^(l-2)
+    auto k2 =
+        hack_make_p(sctx, static_cast<uint128_t>(1) << (l - 2), x.shape());
+    auto b = wrap_add(sctx, x, k2);
+    auto c = wrap_add(sctx, b, r);
+    auto c_p = wrap_a2p(sctx, c);
+    auto c_p_trunc = wrap_arshift_p(sctx, c_p, {static_cast<int64_t>(bits)});
+    auto c_bits = bit_decompose(sctx, c_p);
+    auto c_msb = c_bits.back();
+
+    // k1 = 1
+    auto k1 = hack_make_p(sctx, 1, x.shape());
+    auto e = wrap_mul(sctx, wrap_sub(sctx, k1, r_msb), c_msb);
+    // k3 = 2^(l-d) - 1
+    auto k3 = hack_make_p(sctx, (static_cast<uint128_t>(1) << (l - bits)) - 1,
+                          x.shape());
+    auto f =
+        wrap_add(sctx, wrap_sub(sctx, c_p_trunc, r_hat), wrap_mul(sctx, e, k3));
+
+    // k4 = 2^(l-d-2)
+    auto k4 = hack_make_p(sctx, static_cast<uint128_t>(1) << (l - bits - 2),
+                          x.shape());
+    auto ret = wrap_sub(sctx, f, k4);
+    return ret;
+  });
+}
+
+// Ref:
+// https://www.usenix.org/system/files/sec24summer-prepub-278-liu-fengrun.pdf
+// Protocol 3.2: Fixed-Mult
+NdArrayRef MulAATrunc::proc(KernelEvalContext* ctx, const NdArrayRef& x,
+                            const NdArrayRef& y, size_t bits,
+                            SignType sign) const {
+  (void)sign;  // TODO: optimize me.
+  SPU_ENFORCE(x.numel() == y.numel());
+  SPU_ENFORCE_EQ(x.eltype(), y.eltype());
+
+  // local mul
+  auto tmp_2t = gfmp_mul_mod(x, y);
+
+  const auto field = x.eltype().as<GfmpTy>()->field();
+  auto* sctx = ctx->sctx();
+  std::vector<NdArrayRef> r_bits;
+  NdArrayRef r;
+  std::tie(r_bits, r) = solved_bits(sctx, x.shape());
+  auto zero_shares =
+      gen_zero_shares(ctx, tmp_2t.numel(), sctx->config().sss_threshold() << 1)
+          .reshape(tmp_2t.shape());
+
+  auto r_msb = r_bits.back();
+  return DISPATCH_ALL_FIELDS(field, [&]() {
+    auto l = ScalarTypeToPrime<ring2k_t>::exp;
+    SPU_ENFORCE_LT(bits, l);
+    NdArrayRef r_hat = wrap_make_zeros(sctx, x.shape());
+    for (size_t i = bits; i < l; ++i) {
+      auto k =
+          hack_make_p(sctx, static_cast<uint128_t>(1) << (i - bits), x.shape());
+      r_hat = wrap_add(sctx, r_hat, wrap_mul(sctx, k, r_bits[i]));
+    }
+    for (size_t i = l - bits; i < l; ++i) {
+      auto k = hack_make_p(sctx, static_cast<uint128_t>(1) << i, x.shape());
+      r_hat = wrap_add(sctx, r_hat, wrap_mul(sctx, k, r_msb));
+    }
+
+    NdArrayRef r_2t = wrap_make_zeros(sctx, tmp_2t.shape());
+    for (size_t i = 0; i < l; ++i) {
+      auto k = hack_make_p(sctx, static_cast<uint128_t>(1) << i, x.shape());
+      auto r_bit_square = gfmp_mul_mod(r_bits[i], r_bits[i]);
+      r_2t = wrap_add(sctx, r_2t, wrap_mul(sctx, k, r_bit_square));
+    }
+    r_2t = wrap_add(sctx, r_2t, zero_shares);
+
+    // k2 = 2^(l-2)
+    auto k2 =
+        hack_make_p(sctx, static_cast<uint128_t>(1) << (l - 2), x.shape());
+    auto b = wrap_add(sctx, tmp_2t, k2);
+    auto c = wrap_add(sctx, b, r_2t);
+    auto c_p = wrap_a2p(sctx, c);
+    auto c_p_trunc = wrap_arshift_p(sctx, c_p, {static_cast<int64_t>(bits)});
+    auto c_bits = bit_decompose(sctx, c_p);
+    auto c_msb = c_bits.back();
+
+    // k1 = 1
+    auto k1 = hack_make_p(sctx, 1, x.shape());
+    auto e = wrap_mul(sctx, wrap_sub(sctx, k1, r_msb), c_msb);
+    // k3 = 2^(l-d) - 1
+    auto k3 = hack_make_p(sctx, (static_cast<uint128_t>(1) << (l - bits)) - 1,
+                          x.shape());
+    auto f =
+        wrap_add(sctx, wrap_sub(sctx, c_p_trunc, r_hat), wrap_mul(sctx, e, k3));
+
+    // k4 = 2^(l-d-2)
+    auto k4 = hack_make_p(sctx, static_cast<uint128_t>(1) << (l - bits - 2),
+                          x.shape());
+    auto ret = wrap_sub(sctx, f, k4);
+    return ret;
+  });
+}
+
+NdArrayRef MsbA::proc(KernelEvalContext* ctx, const NdArrayRef& in) const {
+  auto* sctx = ctx->sctx();
+  std::vector<NdArrayRef> r_bits;
+  NdArrayRef r;
+  std::tie(r_bits, r) = solved_bits(sctx, in.shape());
+  const auto k2 = hack_make_p(sctx, 2, in.shape());
+  auto y = wrap_add(sctx, wrap_mul(sctx, in, k2), r);
+  auto y_p = wrap_a2p(sctx, y);
+
+  auto y_p_bits = bit_decompose(sctx, y_p);
+  auto b = wrap_xor(sctx, y_p_bits[0], r_bits[0]);
+  auto c = bit_lt_ap(sctx, y_p_bits, r_bits);
+  auto msb = wrap_xor(sctx, b, c);
+  return msb;
+}
+
+NdArrayRef ReLU::proc(KernelEvalContext* ctx, const NdArrayRef& in) const {
+  auto* sctx = ctx->sctx();
+  std::vector<NdArrayRef> r_bits;
+  NdArrayRef r;
+  std::tie(r_bits, r) = solved_bits(sctx, in.shape());
+  const auto k2 = hack_make_p(sctx, 2, in.shape());
+  auto y = wrap_add(sctx, wrap_mul(sctx, in, k2), r);
+  auto y_p = wrap_a2p(sctx, y);
+
+  auto y_p_bits = bit_decompose(sctx, y_p);
+  auto b = wrap_xor(sctx, y_p_bits[0], r_bits[0]);
+  auto c = bit_lt_ap(sctx, y_p_bits, r_bits);
+  NdArrayRef b_minus_c = wrap_sub(ctx->sctx(), b, c);
+  NdArrayRef t = wrap_mul_aaa(ctx->sctx(), b_minus_c, b_minus_c, in);
+  return wrap_sub(ctx->sctx(), in, t);
+}
+
+void CommonTypeV::evaluate(KernelEvalContext* ctx) const {
+  const Type& lhs = ctx->getParam<Type>(0);
+  const Type& rhs = ctx->getParam<Type>(1);
+
+  SPU_TRACE_MPC_DISP(ctx, lhs, rhs);
+
+  const auto* lhs_v = lhs.as<Priv2kTy>();
+  const auto* rhs_v = rhs.as<Priv2kTy>();
+
+  ctx->pushOutput(makeType<AShrTy>(std::max(lhs_v->field(), rhs_v->field())));
+}
+
+}  // namespace spu::mpc::shamir

--- a/src/libspu/mpc/shamir/conversion.h
+++ b/src/libspu/mpc/shamir/conversion.h
@@ -1,0 +1,138 @@
+// Copyright 2024 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "libspu/mpc/kernel.h"
+
+namespace spu::mpc::shamir {
+
+class A2B : public UnaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "a2b"; }
+
+  Kind kind() const override { return Kind::Dynamic; }
+
+  ce::CExpr latency() const override { return ce::Const(10); }
+
+  ce::CExpr comm() const override {
+    auto nBits = ce::Variable("nBits", "number of Bits");
+    auto sum = ce::Variable("sum", "sum_{i=1}^{nBits} (4i-2)");
+    return ce::K() * (2 + 6 * nBits + 2 * sum);
+  }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& x) const override;
+};
+
+class B2A : public UnaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "b2a"; }
+
+  ce::CExpr latency() const override { return ce::Const(0); }
+
+  ce::CExpr comm() const override { return ce::Const(0); }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& x) const override;
+};
+
+// Todo: put this kernel to arithmetic.h
+class TruncA : public TruncAKernel {
+ public:
+  static constexpr const char* kBindName() { return "trunc_a"; }
+
+  Kind kind() const override { return Kind::Dynamic; }
+
+  ce::CExpr latency() const override { return ce::Const(2); }
+
+  // only count online for now.
+  ce::CExpr comm() const override { return ce::K() * 2; }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& x, size_t bits,
+                  SignType sign) const override;
+
+  bool hasMsbError() const override { return false; }
+
+  // TODO: Add probabilistic truncation (with edabits)
+  TruncLsbRounding lsbRounding() const override {
+    return TruncLsbRounding::Random;
+  }
+};
+
+class MulAATrunc : public MulTruncAKernel {
+ public:
+  static constexpr const char* kBindName() { return "mul_aa_trunc"; }
+
+  Kind kind() const override { return Kind::Dynamic; }
+
+  ce::CExpr latency() const override { return ce::Const(2); }
+
+  // only count online for now.
+  ce::CExpr comm() const override { return ce::K() * 2; }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& x,
+                  const NdArrayRef& y, size_t bits,
+                  SignType sign) const override;
+
+  bool hasMsbError() const override { return false; }
+
+  // TODO: Add probabilistic truncation (with edabits)
+  TruncLsbRounding lsbRounding() const override {
+    return TruncLsbRounding::Random;
+  }
+};
+
+class MsbA : public UnaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "msb_a"; }
+
+  Kind kind() const override { return Kind::Dynamic; }
+
+  ce::CExpr latency() const override { return ce::Const(6); }
+
+  // only count online for now.
+  ce::CExpr comm() const override {
+    auto nBits = ce::Variable("nBits", "number of Bits");
+    return 2 * ce::K() + 2 * ce::K() * nBits;
+  }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& in) const override;
+};
+
+class ReLU : public UnaryKernel {
+ public:
+  static constexpr const char* kBindName() { return "relu"; }
+
+  Kind kind() const override { return Kind::Dynamic; }
+
+  ce::CExpr latency() const override { return ce::Const(6); }
+
+  // only count online for now.
+  ce::CExpr comm() const override {
+    auto nBits = ce::Variable("nBits", "number of Bits");
+    return 4 * ce::K() + 2 * ce::K() * nBits;
+  }
+
+  NdArrayRef proc(KernelEvalContext* ctx, const NdArrayRef& in) const override;
+};
+
+class CommonTypeV : public Kernel {
+ public:
+  static constexpr const char* kBindName() { return "common_type_v"; }
+
+  Kind kind() const override { return Kind::Dynamic; }
+
+  void evaluate(KernelEvalContext* ctx) const override;
+};
+
+}  // namespace spu::mpc::shamir

--- a/src/libspu/mpc/shamir/io.cc
+++ b/src/libspu/mpc/shamir/io.cc
@@ -1,0 +1,85 @@
+// Copyright 2024 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "libspu/mpc/shamir/io.h"
+
+#include "libspu/core/context.h"
+#include "libspu/mpc/common/pv_gfmp.h"
+#include "libspu/mpc/shamir/type.h"
+#include "libspu/mpc/utils/gfmp_ops.h"
+#include "libspu/mpc/utils/ring_ops.h"
+
+namespace spu::mpc::shamir {
+
+Type ShamirIo::getShareType(Visibility vis, int owner_rank) const {
+  if (vis == VIS_PUBLIC) {
+    return makeType<PubGfmpTy>(field_);
+  } else if (vis == VIS_SECRET) {
+    SPU_ENFORCE(owner_rank == -1, "Private type is not supported");
+    return makeType<AShrTy>(field_);
+  }
+
+  SPU_THROW("unsupported vis type {}", vis);
+}
+
+std::vector<NdArrayRef> ShamirIo::toShares(const NdArrayRef& raw,
+                                           Visibility vis,
+                                           int owner_rank) const {
+  SPU_ENFORCE(raw.eltype().isa<GfmpTy>(), "expected field type, got {}",
+              raw.eltype());
+  const auto field = raw.eltype().as<Ring2k>()->field();
+  SPU_ENFORCE(field == field_, "expect raw value encoded in field={}, got={}",
+              field_, field);
+
+  if (vis == VIS_PUBLIC) {
+    const auto share = raw.as(makeType<PubGfmpTy>(field));
+    return std::vector<NdArrayRef>(world_size_, share);
+  } else if (vis == VIS_SECRET) {
+    SPU_ENFORCE(owner_rank == -1, "private type is not supported");
+
+    // by default, make as arithmetic share.
+    std::vector<NdArrayRef> shares =
+        gfmp_rand_shamir_shares(raw, world_size_, threshold_);
+
+    for (size_t i = 0; i < shares.size(); ++i) {
+      shares[i] = shares[i].as(makeType<AShrTy>(field));
+    }
+    return shares;
+  }
+
+  SPU_THROW("unsupported vis type {}", vis);
+}
+
+NdArrayRef ShamirIo::fromShares(const std::vector<NdArrayRef>& shares) const {
+  const auto& eltype = shares.at(0).eltype();
+
+  if (eltype.isa<PubGfmpTy>()) {
+    SPU_ENFORCE(field_ == eltype.as<Ring2k>()->field());
+    return shares[0].as(makeType<GfmpTy>(field_));
+  } else if (eltype.isa<AShrTy>()) {
+    SPU_ENFORCE(field_ == eltype.as<Ring2k>()->field());
+    return gfmp_reconstruct_shamir_shares(shares, world_size_, threshold_);
+  }
+  SPU_THROW("unsupported eltype {}", eltype);
+}
+
+std::unique_ptr<ShamirIo> makeShamirIo(FieldType field, size_t npc,
+                                       size_t threshold) {
+  SPU_ENFORCE(npc >= threshold * 2 + 1 && threshold >= 1,
+              "invalid party numbers {} or threshold {}", npc, threshold);
+  registerTypes();
+  return std::make_unique<ShamirIo>(field, npc, threshold);
+}
+
+}  // namespace spu::mpc::shamir

--- a/src/libspu/mpc/shamir/io.h
+++ b/src/libspu/mpc/shamir/io.h
@@ -1,0 +1,42 @@
+// Copyright 2024 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "libspu/mpc/io_interface.h"
+
+namespace spu::mpc::shamir {
+
+class ShamirIo final : public BaseIo {
+ private:
+  size_t const threshold_;
+
+ public:
+  using BaseIo::BaseIo;
+
+  explicit ShamirIo(FieldType field, size_t world_size, size_t threshold)
+      : BaseIo(field, world_size), threshold_(threshold) {}
+
+  std::vector<NdArrayRef> toShares(const NdArrayRef& raw, Visibility vis,
+                                   int owner_rank) const override;
+
+  Type getShareType(Visibility vis, int owner_rank = -1) const override;
+
+  NdArrayRef fromShares(const std::vector<NdArrayRef>& shares) const override;
+};
+
+std::unique_ptr<ShamirIo> makeShamirIo(FieldType field, size_t npc,
+                                       size_t threshold);
+
+}  // namespace spu::mpc::shamir

--- a/src/libspu/mpc/shamir/io_test.cc
+++ b/src/libspu/mpc/shamir/io_test.cc
@@ -1,0 +1,31 @@
+// Copyright 2024 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "libspu/mpc/shamir/io.h"
+
+#include "libspu/mpc/io_shamir_test.h"
+
+namespace spu::mpc::shamir {
+
+INSTANTIATE_TEST_SUITE_P(
+    ShamirIoTest, ShamirIoTest,
+    testing::Combine(testing::Values(makeShamirIo),  //
+                     testing::Values(4),             //
+                     testing::Values(FieldType::FM32, FieldType::FM64,
+                                     FieldType::FM128)),
+    [](const testing::TestParamInfo<ShamirIoTest::ParamType>& p) {
+      return fmt::format("{}x{}", std::get<1>(p.param), std::get<2>(p.param));
+    });
+
+}  // namespace spu::mpc::shamir

--- a/src/libspu/mpc/shamir/protocol.cc
+++ b/src/libspu/mpc/shamir/protocol.cc
@@ -1,0 +1,79 @@
+// Copyright 2024 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "libspu/mpc/shamir/protocol.h"
+
+#include "libspu/mpc/common/communicator.h"
+#include "libspu/mpc/common/prg_state.h"
+#include "libspu/mpc/common/pv2k.h"
+#include "libspu/mpc/common/pv_gfmp.h"
+#include "libspu/mpc/shamir/arithmetic.h"
+#include "libspu/mpc/shamir/boolean.h"
+#include "libspu/mpc/shamir/conversion.h"
+#include "libspu/mpc/shamir/type.h"
+#include "libspu/mpc/standard_shape/protocol.h"
+
+namespace spu::mpc {
+
+void regShamirProtocol(SPUContext* ctx,
+                       const std::shared_ptr<yacl::link::Context>& lctx) {
+  shamir::registerTypes();
+
+  // add communicator
+  ctx->prot()->addState<Communicator>(lctx);
+
+  // register random states & kernels.
+  ctx->prot()->addState<PrgState>(lctx);
+
+  // add Z2k state.
+  ctx->prot()->addState<Z2kState>(ctx->config().field());
+
+  // register public kernels.
+  regPVGfmpKernels(ctx->prot());
+
+  // Register standard shape ops
+  regStandardShapeOps(ctx);
+
+  // register arithmetic & binary kernels
+  ctx->prot()
+      ->regKernel<
+          shamir::P2A, shamir::A2P, shamir::A2V, shamir::V2A,
+          shamir::RandA,                                                 //
+          shamir::NegateA,                                               //
+          shamir::AddAP, shamir::AddAA,                                  //
+          shamir::MulAP, shamir::MulAA, shamir::MulAAP, shamir::MulAAA,  //
+          shamir::MatMulAP, shamir::MatMulAA,                            //
+          shamir::LShiftB, shamir::RShiftB, shamir::ARShiftB,
+          shamir::CommonTypeB, shamir::CastTypeB,         //
+          shamir::CommonTypeV, shamir::A2B, shamir::B2A,  //
+          shamir::AndBP, shamir::XorBP,                   //
+          shamir::P2B, shamir::B2P, shamir::B2V, shamir::XorBB, shamir::AndBB,
+          shamir::BitrevB, shamir::TruncA, shamir::MulAATrunc,
+          shamir::MsbA, shamir::ReLU,  //
+          shamir::BitIntlB, shamir::BitDeintlB>();
+}
+
+std::unique_ptr<SPUContext> makeShamirProtocol(
+    const RuntimeConfig& conf,
+    const std::shared_ptr<yacl::link::Context>& lctx) {
+  shamir::registerTypes();
+
+  auto ctx = std::make_unique<SPUContext>(conf, lctx);
+
+  regShamirProtocol(ctx.get(), lctx);
+
+  return ctx;
+}
+
+}  // namespace spu::mpc

--- a/src/libspu/mpc/shamir/protocol.h
+++ b/src/libspu/mpc/shamir/protocol.h
@@ -1,0 +1,30 @@
+// Copyright 2024 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "yacl/link/context.h"
+
+#include "libspu/core/context.h"
+
+namespace spu::mpc {
+
+void regShamirProtocol(SPUContext* ctx,
+                       const std::shared_ptr<yacl::link::Context>& lctx);
+
+std::unique_ptr<SPUContext> makeShamirProtocol(
+    const RuntimeConfig& conf,
+    const std::shared_ptr<yacl::link::Context>& lctx);
+
+}  // namespace spu::mpc

--- a/src/libspu/mpc/shamir/protocol_test.cc
+++ b/src/libspu/mpc/shamir/protocol_test.cc
@@ -1,0 +1,83 @@
+// Copyright 2024 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "libspu/mpc/shamir/protocol.h"
+
+#include "libspu/mpc/ab_api.h"
+#include "libspu/mpc/ab_api_test.h"
+#include "libspu/mpc/api.h"
+#include "libspu/mpc/api_test.h"
+
+namespace spu::mpc::test {
+namespace {
+
+RuntimeConfig makeConfig(FieldType field) {
+  RuntimeConfig conf;
+  conf.set_protocol(ProtocolKind::SHAMIR);
+  conf.set_field(field);
+  conf.set_sss_threshold(1);
+  return conf;
+}
+
+}  // namespace
+
+INSTANTIATE_TEST_SUITE_P(
+    Shamir, ApiTest,
+    testing::Combine(testing::Values(makeShamirProtocol),            //
+                     testing::Values(makeConfig(FieldType::FM32),    //
+                                     makeConfig(FieldType::FM64),    //
+                                     makeConfig(FieldType::FM128)),  //
+                     testing::Values(3)),                            //
+    [](const testing::TestParamInfo<ApiTest::ParamType>& p) {
+      return fmt::format("{}x{}", std::get<1>(p.param).field(),
+                         std::get<2>(p.param));
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    Shamir, ArithmeticTest,
+    testing::Combine(testing::Values(makeShamirProtocol),            //
+                     testing::Values(makeConfig(FieldType::FM32),    //
+                                     makeConfig(FieldType::FM64),    //
+                                     makeConfig(FieldType::FM128)),  //
+                     testing::Values(3)),                            //
+    [](const testing::TestParamInfo<ArithmeticTest::ParamType>& p) {
+      return fmt::format("{}x{}", std::get<1>(p.param).field(),
+                         std::get<2>(p.param));
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    Shamir, BooleanTest,
+    testing::Combine(testing::Values(makeShamirProtocol),            //
+                     testing::Values(makeConfig(FieldType::FM32),    //
+                                     makeConfig(FieldType::FM64),    //
+                                     makeConfig(FieldType::FM128)),  //
+                     testing::Values(3)),                            //
+    [](const testing::TestParamInfo<BooleanTest::ParamType>& p) {
+      return fmt::format("{}x{}", std::get<1>(p.param).field(),
+                         std::get<2>(p.param));
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    Shamir, ConversionTest,
+    testing::Combine(testing::Values(makeShamirProtocol),            //
+                     testing::Values(makeConfig(FieldType::FM32),    //
+                                     makeConfig(FieldType::FM64),    //
+                                     makeConfig(FieldType::FM128)),  //
+                     testing::Values(3)),                            //
+    [](const testing::TestParamInfo<BooleanTest::ParamType>& p) {
+      return fmt::format("{}x{}", std::get<1>(p.param).field(),
+                         std::get<2>(p.param));
+    });
+
+}  // namespace spu::mpc::test

--- a/src/libspu/mpc/shamir/type.cc
+++ b/src/libspu/mpc/shamir/type.cc
@@ -1,0 +1,32 @@
+// Copyright 2024 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "libspu/mpc/shamir/type.h"
+
+#include <mutex>
+
+#include "libspu/mpc/common/pv_gfmp.h"
+
+namespace spu::mpc::shamir {
+
+void registerTypes() {
+  regPVGfmpTypes();
+
+  static std::once_flag flag;
+  std::call_once(flag, []() {
+    TypeContext::getTypeContext()->addTypes<AShrTy, BShrTy>();
+  });
+}
+
+}  // namespace spu::mpc::shamir

--- a/src/libspu/mpc/shamir/type.h
+++ b/src/libspu/mpc/shamir/type.h
@@ -1,0 +1,72 @@
+// Copyright 2024 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "libspu/core/type.h"
+
+namespace spu::mpc::shamir {
+
+class AShrTy : public TypeImpl<AShrTy, GfmpTy, Secret, AShare> {
+  using Base = TypeImpl<AShrTy, GfmpTy, Secret, AShare>;
+
+ public:
+  using Base::Base;
+  static std::string_view getStaticId() { return "shamir.AShr"; }
+  explicit AShrTy(FieldType field) {
+    field_ = field;
+    mersenne_prime_exp_ = GetMersennePrimeExp(field);
+    prime_ = (static_cast<uint128_t>(1) << mersenne_prime_exp_) - 1;
+  }
+};
+
+class BShrTy : public TypeImpl<BShrTy, RingTy, Secret, BShare> {
+  using Base = TypeImpl<BShrTy, RingTy, Secret, BShare>;
+
+  static constexpr size_t kDefaultNumBits = std::numeric_limits<size_t>::max();
+
+ public:
+  using Base::Base;
+  explicit BShrTy(FieldType field, size_t nbits = kDefaultNumBits) {
+    field_ = field;
+    nbits_ = nbits == kDefaultNumBits ? SizeOf(field) * 8 : nbits;
+  }
+
+  static std::string_view getStaticId() { return "shamir.BShr"; }
+
+  size_t size() const override { return SizeOf(field_) * nbits_; }
+
+  void fromString(std::string_view detail) override {
+    auto comma = detail.find_first_of(',');
+    auto field_str = detail.substr(0, comma);
+    auto nbits_str = detail.substr(comma + 1);
+    SPU_ENFORCE(FieldType_Parse(std::string(field_str), &field_),
+                "parse failed from={}", detail);
+    nbits_ = std::stoul(std::string(nbits_str));
+  }
+
+  std::string toString() const override {
+    return fmt::format("{},{}", FieldType_Name(field()), nbits_);
+  }
+
+  bool equals(TypeObject const* other) const override {
+    auto const* derived_other = dynamic_cast<BShrTy const*>(other);
+    SPU_ENFORCE(derived_other);
+    return field_ == derived_other->field_ && nbits_ == derived_other->nbits();
+  }
+};
+
+void registerTypes();
+
+}  // namespace spu::mpc::shamir

--- a/src/libspu/mpc/shamir/type_test.cc
+++ b/src/libspu/mpc/shamir/type_test.cc
@@ -1,0 +1,75 @@
+// Copyright 2024 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "libspu/mpc/shamir/type.h"
+
+#include "gtest/gtest.h"
+
+namespace spu::mpc::shamir {
+
+TEST(AShrTy, Simple) {
+  registerTypes();
+  {
+    Type ty = makeType<AShrTy>(FM32);
+    EXPECT_EQ(ty.size(), 4);
+
+    EXPECT_TRUE(ty.isa<Secret>());
+    EXPECT_TRUE(ty.isa<Ring2k>());
+    EXPECT_FALSE(ty.isa<Public>());
+    EXPECT_TRUE(ty.isa<AShare>());
+    EXPECT_TRUE(ty.isa<GfmpTy>());
+    EXPECT_TRUE(ty.as<GfmpTy>()->mp_exp() == 31);
+    EXPECT_TRUE(ty.as<GfmpTy>()->p() ==
+                (static_cast<uint128_t>(1) << ty.as<GfmpTy>()->mp_exp()) - 1);
+
+    EXPECT_EQ(ty.toString(), "shamir.AShr<FM32,31>");
+
+    EXPECT_EQ(Type::fromString(ty.toString()), ty);
+  }
+}
+
+TEST(BShrTy, Simple) {
+  {
+    Type ty = makeType<BShrTy>(FM128);
+    EXPECT_EQ(ty.size(), 16 * 128);
+
+    EXPECT_TRUE(ty.isa<Secret>());
+    EXPECT_TRUE(ty.isa<Ring2k>());
+    EXPECT_FALSE(ty.isa<Public>());
+    EXPECT_FALSE(ty.isa<AShare>());
+    EXPECT_TRUE(ty.isa<BShare>());
+
+    EXPECT_EQ(ty.toString(), "shamir.BShr<FM128,128>");
+
+    EXPECT_EQ(Type::fromString(ty.toString()), ty);
+  }
+
+  // Semi2k::BShr constructor with field and nbits.
+  {
+    Type ty = makeType<BShrTy>(FM128, 7);
+    EXPECT_EQ(ty.size(), 16 * 7);
+
+    EXPECT_TRUE(ty.isa<Secret>());
+    EXPECT_TRUE(ty.isa<Ring2k>());
+    EXPECT_FALSE(ty.isa<Public>());
+    EXPECT_FALSE(ty.isa<AShare>());
+    EXPECT_TRUE(ty.isa<BShare>());
+
+    EXPECT_EQ(ty.toString(), "shamir.BShr<FM128,7>");
+
+    EXPECT_EQ(Type::fromString(ty.toString()), ty);
+  }
+}
+
+}  // namespace spu::mpc::shamir

--- a/src/libspu/mpc/shamir/value.cc
+++ b/src/libspu/mpc/shamir/value.cc
@@ -1,0 +1,36 @@
+// Copyright 2024 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "libspu/mpc/shamir/value.h"
+
+#include "libspu/core/prelude.h"
+#include "libspu/mpc/shamir/type.h"
+
+namespace spu::mpc::shamir {
+
+NdArrayRef getBitShare(const NdArrayRef& in, size_t bit_idx) {
+  SPU_ENFORCE(in.eltype().isa<BShare>());
+  auto nbits = in.eltype().as<BShrTy>()->nbits();
+  auto field = in.eltype().as<BShrTy>()->field();
+  SPU_ENFORCE_GT(nbits, bit_idx);
+
+  auto new_strides = in.strides();
+  std::transform(new_strides.cbegin(), new_strides.cend(), new_strides.begin(),
+                 [nbits](int64_t s) { return nbits * s; });
+  const auto ty = makeType<AShrTy>(field);
+  return NdArrayRef(in.buf(), ty, in.shape(), new_strides,
+                    in.offset() + bit_idx * static_cast<int64_t>(ty.size()));
+}
+
+}  // namespace spu::mpc::shamir

--- a/src/libspu/mpc/shamir/value.h
+++ b/src/libspu/mpc/shamir/value.h
@@ -1,0 +1,42 @@
+// Copyright 2024 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "libspu/core/ndarray_ref.h"
+#include "libspu/core/type_util.h"
+
+namespace spu::mpc::shamir {
+
+// The layout of Shamir Bshare.
+//
+// Shamir Bshare is a set of packed bit shares.
+// Each bit share is 0/1 decoded on a field of Gfmp whose size is k. Nbits b
+// shares are compacted to form an entire bshare.
+//
+//   element                    address
+//   x[0].share_0               0
+//   x[0].share_1               k
+//   ...
+//   x[0].share_(nbits-1)       (nbits-1)*k
+//   ...
+//   x[n-1].share_0             (n-1)*nbits*k+0
+//   a[n-1].share_1             (n-1)*nbits*k+k
+//
+
+NdArrayRef getBitShare(const NdArrayRef& in, size_t bit_idx);
+
+#define PFOR_GRAIN_SIZE 8192
+
+}  // namespace spu::mpc::shamir

--- a/src/libspu/mpc/utils/BUILD.bazel
+++ b/src/libspu/mpc/utils/BUILD.bazel
@@ -91,6 +91,14 @@ spu_cc_test(
     ],
 )
 
+spu_cc_test(
+    name = "gfmp_ops_test",
+    srcs = ["gfmp_ops_test.cc"],
+    deps = [
+        ":gfmp_ops",
+    ],
+)
+
 spu_cc_library(
     name = "gfmp_ops",
     srcs = ["gfmp_ops.cc"],

--- a/src/libspu/mpc/utils/gfmp_ops.cc
+++ b/src/libspu/mpc/utils/gfmp_ops.cc
@@ -57,6 +57,36 @@ void gfmp_mod_impl(NdArrayRef& ret, const NdArrayRef& x) {
   });
 }
 
+// batch inversion
+void gfmp_inverse_impl(NdArrayRef& ret, const NdArrayRef& x) {
+  ENFORCE_EQ_ELSIZE_AND_SHAPE(ret, x);
+  const auto* ty = x.eltype().as<GfmpTy>();
+  const auto field = ty->field();
+  const auto numel = x.numel();
+
+  NdArrayRef prefix_prod(ret.eltype(), ret.shape());
+
+  DISPATCH_ALL_FIELDS(field, [&]() {
+    NdArrayView<ring2k_t> _prefix_prod(prefix_prod);
+    NdArrayView<ring2k_t> _x(x);
+    NdArrayView<ring2k_t> _ret(ret);
+    _prefix_prod[0] = _x[0];
+    // TODO optimize prefix_mult in parallel
+    for (int64_t i = 1; i < numel; ++i) {
+      _prefix_prod[i] = mul_mod(_prefix_prod[i - 1], _x[i]);
+    }
+
+    _ret[numel - 1] = mul_inv(_prefix_prod[numel - 1]);
+    for (int64_t i = numel - 1; i >= 1; i--) {
+      _ret[i - 1] = mul_mod(_ret[i], _x[i]);
+    }
+
+    for (int64_t i = 1; i < numel; ++i) {
+      _ret[i] = mul_mod(_ret[i], _prefix_prod[i - 1]);
+    }
+  });
+}
+
 void gfmp_mul_mod_impl(NdArrayRef& ret, const NdArrayRef& x,
                        const NdArrayRef& y) {
   ENFORCE_EQ_ELSIZE_AND_SHAPE(ret, x);
@@ -124,6 +154,7 @@ void gfmp_div_mod_impl(NdArrayRef& ret, const NdArrayRef& x,
 }
 
 }  // namespace
+
 NdArrayRef gfmp_zeros(FieldType field, const Shape& shape) {
   NdArrayRef ret(makeType<GfmpTy>(field), shape);
   auto numel = ret.numel();
@@ -134,22 +165,26 @@ NdArrayRef gfmp_zeros(FieldType field, const Shape& shape) {
     return ret;
   });
 }
+
 NdArrayRef gfmp_rand(FieldType field, const Shape& shape) {
   uint64_t cnt = 0;
   return gfmp_rand(field, shape, yacl::crypto::SecureRandSeed(), &cnt);
 }
+
+// FIXME: this function is not strictly correct as the probability among the
+// range [0, p-1] is not uniform.
 
 NdArrayRef gfmp_rand(FieldType field, const Shape& shape, uint128_t prg_seed,
                      uint64_t* prg_counter) {
   constexpr yacl::crypto::SymmetricCrypto::CryptoType kCryptoType =
       yacl::crypto::SymmetricCrypto::CryptoType::AES128_CTR;
   constexpr uint128_t kAesInitialVector = 0U;
+
   NdArrayRef res(makeType<GfmpTy>(field), shape);
-  DISPATCH_ALL_FIELDS(field, [&]() {
-    *prg_counter = yacl::crypto::FillPRandWithMersennePrime<ring2k_t>(
-        kCryptoType, prg_seed, kAesInitialVector, *prg_counter,
-        absl::MakeSpan(&res.at<ring2k_t>(0), res.numel()));
-  });
+  *prg_counter = yacl::crypto::FillPRand(
+      kCryptoType, prg_seed, kAesInitialVector, *prg_counter,
+      absl::MakeSpan(res.data<char>(), res.buf()->size()));
+  gfmp_mod_(res);
   return res;
 }
 
@@ -163,6 +198,13 @@ NdArrayRef gfmp_mod(const NdArrayRef& x) {
 void gfmp_mod_(NdArrayRef& x) {
   SPU_ENFORCE_GFMP(x);
   gfmp_mod_impl(x, x);
+}
+
+NdArrayRef gfmp_batch_inverse(const NdArrayRef& x) {
+  SPU_ENFORCE_GFMP(x);
+  NdArrayRef ret(x.eltype(), x.shape());
+  gfmp_inverse_impl(ret, x);
+  return ret;
 }
 
 NdArrayRef gfmp_mul_mod(const NdArrayRef& x, const NdArrayRef& y) {
@@ -246,6 +288,156 @@ NdArrayRef gfmp_exp_mod(const NdArrayRef& x, const NdArrayRef& y) {
 
 void gfmp_exp_mod_(NdArrayRef& x, const NdArrayRef& y) {
   gfmp_exp_mod_impl(x, x, y);
+}
+
+NdArrayRef gfmp_mmul_mod(const NdArrayRef& x, const NdArrayRef& y) {
+  SPU_ENFORCE_GFMP(x);
+  SPU_ENFORCE_GFMP(y);
+  const auto field = x.eltype().as<GfmpTy>()->field();
+
+  // Optimize me: remove copy
+  return DISPATCH_ALL_FIELDS(field, [&]() {
+    GfmpMatrix<ring2k_t> x_(x.shape()[0], x.shape()[1]);
+    GfmpMatrix<ring2k_t> y_(y.shape()[0], y.shape()[1]);
+    for (auto i = 0; i < x_.rows(); ++i) {
+      for (auto j = 0; j < x_.cols(); ++j) {
+        x_(i, j) = Gfmp(x.at<ring2k_t>({i, j}));
+      }
+    }
+    for (auto i = 0; i < y_.rows(); ++i) {
+      for (auto j = 0; j < y_.cols(); ++j) {
+        y_(i, j) = Gfmp(y.at<ring2k_t>({i, j}));
+      }
+    }
+    auto z_ = x_ * y_;
+    NdArrayRef out(x.eltype(), {x.shape()[0], y.shape()[1]});
+    NdArrayView<ring2k_t> _out(out);
+    for (auto i = 0; i < z_.rows(); ++i) {
+      for (auto j = 0; j < z_.cols(); ++j) {
+        _out[i * z_.cols() + j] = z_(i, j).data();
+      }
+    }
+    return out;
+  });
+}
+
+NdArrayRef gfmp_arshift_mod(const NdArrayRef& in, const Sizes& bits) {
+  SPU_ENFORCE_GFMP(in);
+  const auto* ty = in.eltype().as<GfmpTy>();
+  const auto field = ty->field();
+  bool is_splat = bits.size() == 1;
+  NdArrayRef out(in.eltype(), in.shape());
+  DISPATCH_ALL_FIELDS(field, [&]() {
+    using ring_2k_s = std::make_signed_t<ring2k_t>;
+    size_t exp = ScalarTypeToPrime<ring2k_t>::exp;
+    ring2k_t prime = ScalarTypeToPrime<ring2k_t>::prime;
+    auto mask = static_cast<ring2k_t>(0xFF) << (exp - 1);
+    NdArrayView<ring2k_t> _in(in);
+    NdArrayView<ring2k_t> _out(out);
+    pforeach(0, in.numel(), [&](int64_t idx) {
+      auto msb = (_in[idx] >> (exp - 1)) & 1;
+      auto mask_ = msb ? mask : 0;
+      auto tmp = (_in[idx] & ~mask) | mask_;
+      auto shift =
+          static_cast<ring_2k_s>(tmp) >> (is_splat ? bits[0] : bits[idx]);
+      _out[idx] = shift & prime;
+    });
+  });
+  return out;
+}
+
+std::vector<NdArrayRef> gfmp_rand_shamir_shares(const NdArrayRef& x,
+                                                size_t world_size,
+                                                size_t threshold) {
+  auto field = x.eltype().as<GfmpTy>()->field();
+  auto coeffs = gfmp_rand(field, {static_cast<int64_t>(threshold) * x.numel()});
+  return gfmp_rand_shamir_shares(x, coeffs, world_size, threshold);
+}
+
+std::vector<NdArrayRef> gfmp_rand_shamir_shares(const NdArrayRef& x,
+                                                const NdArrayRef& coeffs,
+                                                size_t world_size,
+                                                size_t threshold) {
+  SPU_ENFORCE_GFMP(x);
+  SPU_ENFORCE(world_size > threshold && threshold >= 1,
+              "invalid party numbers {} or threshold {}", world_size,
+              threshold);
+  SPU_ENFORCE_EQ(coeffs.numel(), static_cast<int64_t>(threshold) * x.numel());
+  const auto* ty = x.eltype().as<GfmpTy>();
+  const auto field = ty->field();
+  // For each element, we need to generate `threshold` random coefficients
+  std::vector<NdArrayRef> shares;
+  shares.reserve(world_size);
+  for (size_t i = 0; i < world_size; ++i) {
+    shares.emplace_back(x.eltype(), x.shape());
+  }
+
+  DISPATCH_ALL_FIELDS(field, [&]() {
+    NdArrayView<ring2k_t> _x(x);
+    NdArrayView<ring2k_t> _coeffs(coeffs);
+    pforeach(0, x.numel(), [&](int64_t idx) {
+      for (size_t i = 1; i <= world_size; ++i) {
+        ring2k_t share = _x[idx];
+        size_t coeff_beg = 0 + idx * threshold;
+        for (size_t j = 1; j < threshold + 1; ++j) {
+          ring2k_t coeff = _coeffs[coeff_beg + j - 1];
+          for (size_t k = 0; k < j; k++) {
+            coeff = mul_mod(coeff, static_cast<ring2k_t>(i));
+          }
+          share = add_mod(share, coeff);
+        }
+        NdArrayView<ring2k_t> _share(shares[i - 1]);
+        _share[idx] = share;
+      }
+    });
+  });
+  return shares;
+}
+
+NdArrayRef gfmp_reconstruct_shamir_shares(absl::Span<const NdArrayRef> shares,
+                                          size_t world_size, size_t threshold) {
+  SPU_ENFORCE(std::all_of(shares.begin(), shares.end(),
+                          [&](const NdArrayRef& x) {
+                            return x.eltype() == shares[0].eltype() &&
+                                   x.shape() == shares[0].shape() &&
+                                   x.eltype().isa<GfmpTy>();
+                          }),
+              "Share shape and type should be the same");
+  SPU_ENFORCE_GE(shares.size(), threshold,
+                 "Shares size and threshold are not matched");
+  SPU_ENFORCE(world_size >= threshold * 2 + 1 && threshold >= 1,
+              "invalid party numbers {} or threshold {}", world_size,
+              threshold);
+  const auto* ty = shares[0].eltype().as<GfmpTy>();
+  const auto field = ty->field();
+  const auto numel = shares[0].numel();
+  NdArrayRef out(makeType<GfmpTy>(field), shares[0].shape());
+
+  DISPATCH_ALL_FIELDS(field, [&]() {
+    NdArrayView<ring2k_t> _out(out);
+    pforeach(0, numel, [&](int64_t idx) {
+      ring2k_t secret = 0;
+      // TODO optimize me: the reconstruction vector for a fixed point can be
+      // pre-computed
+      for (size_t i = 0; i < shares.size(); ++i) {
+        NdArrayView<ring2k_t> _share(shares[i]);
+        ring2k_t y = _share[idx];
+        ring2k_t prod = 1;
+        for (size_t j = 0; j < shares.size(); ++j) {
+          if (i != j) {
+            ring2k_t xi = i + 1;
+            ring2k_t xj = j + 1;
+            auto tmp = mul_mod(xj, mul_inv(add_mod(xj, add_inv(xi))));
+            prod = mul_mod(prod, tmp);
+          }
+        }
+        auto tmp = mul_mod(y, prod);
+        secret = add_mod(secret, tmp);
+      }
+      _out[idx] = secret;
+    });
+  });
+  return out;
 }
 
 }  // namespace spu::mpc

--- a/src/libspu/mpc/utils/gfmp_ops.h
+++ b/src/libspu/mpc/utils/gfmp_ops.h
@@ -27,6 +27,8 @@ NdArrayRef gfmp_zeros(FieldType field, const Shape& shape);
 NdArrayRef gfmp_mod(const NdArrayRef& x);
 void gfmp_mod_(NdArrayRef& x);
 
+NdArrayRef gfmp_batch_inverse(const NdArrayRef& x);
+
 NdArrayRef gfmp_mul_mod(const NdArrayRef& x, const NdArrayRef& y);
 void gfmp_mul_mod_(NdArrayRef& x, const NdArrayRef& y);
 
@@ -41,5 +43,21 @@ void gfmp_sub_mod_(NdArrayRef& x, const NdArrayRef& y);
 
 NdArrayRef gfmp_exp_mod(const NdArrayRef& x, const NdArrayRef& y);
 void gfmp_exp_mod_(NdArrayRef& x, const NdArrayRef& y);
+
+NdArrayRef gfmp_mmul_mod(const NdArrayRef& x, const NdArrayRef& y);
+NdArrayRef gfmp_arshift_mod(const NdArrayRef& x, const Sizes& bits);
+
+std::vector<NdArrayRef> gfmp_rand_shamir_shares(const NdArrayRef& x,
+                                                const NdArrayRef& coeffs,
+                                                size_t world_size,
+                                                size_t threshold);
+
+std::vector<NdArrayRef> gfmp_rand_shamir_shares(const NdArrayRef& x,
+                                                size_t world_size,
+                                                size_t threshold);
+
+NdArrayRef gfmp_reconstruct_shamir_shares(absl::Span<const NdArrayRef> shares,
+                                          size_t world_size, size_t threshold);
+
 
 }  // namespace spu::mpc

--- a/src/libspu/mpc/utils/gfmp_ops_test.cc
+++ b/src/libspu/mpc/utils/gfmp_ops_test.cc
@@ -1,0 +1,78 @@
+// Copyright 2021 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "libspu/mpc/utils/gfmp_ops.h"
+
+#include <random>
+
+#include "gtest/gtest.h"
+
+#include "libspu/mpc/utils/ring_ops.h"
+
+namespace spu::mpc {
+
+class GfmpArrayRefTest
+    : public ::testing::TestWithParam<std::tuple<FieldType, int64_t, int64_t>> {
+};
+
+static NdArrayRef makeRandomArray(FieldType field, int64_t numel,
+                                  int64_t stride) {
+  const Type ty = makeType<GfmpTy>(field);
+  const size_t buf_size = SizeOf(field) * numel * stride;
+
+  auto buf = std::make_shared<yacl::Buffer>(buf_size);
+  {
+    size_t numOfInts = buf_size / sizeof(int32_t);
+    auto* begin = buf->data<int32_t>();
+    for (size_t idx = 0; idx < numOfInts; idx++) {
+      *(begin + idx) = std::rand();
+    }
+  }
+  return gfmp_mod(NdArrayRef(buf, ty, {numel}, {stride}, 0));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    GfmpArrayRefTestSuite, GfmpArrayRefTest,
+    testing::Combine(testing::Values(FM32, FM64, FM128),  //
+                     testing::Values(1, 3, 10000),        // size of parameters
+                     testing::Values(1, 3)  // stride of first param
+                     ),
+    [](const testing::TestParamInfo<GfmpArrayRefTest::ParamType>& p) {
+      return fmt::format("{}x{}x{}", std::get<0>(p.param), std::get<1>(p.param),
+                         std::get<2>(p.param));
+    });
+
+TEST_P(GfmpArrayRefTest, BatchInverse) {
+  const FieldType field = std::get<0>(GetParam());
+  const int64_t numel = std::get<1>(GetParam());
+  const int64_t stride = std::get<2>(GetParam());
+  const Type ty = makeType<RingTy>(field);
+
+  // GIVEN
+  const NdArrayRef y = makeRandomArray(field, numel, stride);
+  DISPATCH_ALL_FIELDS(field, [&]() {
+    NdArrayView<ring2k_t> _y(y);
+    pforeach(0, numel, [&](int64_t idx) { _y[idx] = idx + 1; });
+  });
+
+  NdArrayRef x = gfmp_batch_inverse(y);
+  NdArrayRef ones = ring_ones(field, y.shape());
+  // WHEN
+  NdArrayRef z = gfmp_mul_mod(x, y);  // x = y;
+
+  // THEN
+  EXPECT_TRUE(ring_all_equal(z, ones));
+}
+
+}  // namespace spu::mpc

--- a/src/libspu/spu.proto
+++ b/src/libspu/spu.proto
@@ -126,6 +126,10 @@ enum ProtocolKind {
   // A semi-honest 3PC-protocol for Neural Network, P2 as the helper,
   // (https://eprint.iacr.org/2018/442)
   SECURENN = 5;
+
+  // A semi-honest multi-party protocol in the honest-majority setting.
+  // (https://www.usenix.org/conference/usenixsecurity24/presentation/liu-fengrun)
+  SHAMIR = 6;
 }
 
 message ValueMetaProto {
@@ -334,6 +338,9 @@ message RuntimeConfig {
   // For protocol like SecureML, the most significant bit may have error with
   // low probability, which lead to huge calculation error.
   bool trunc_allow_msb_error = 73;
+
+  // Threshold for shamir secret sharing.
+  uint64 sss_threshold = 74;
 
   /// System related configurations start.
 


### PR DESCRIPTION
# Pull Request

## What problem does this PR solve?

主要修改&优化：

- libspu/mpc/utils/gfmp_ops.cc
       * 修改gfmp_reconstruct_shamir_shares中的公式
       * 增加batch_inversion操作，以及相应的gtest
- libspu/mpc/shamir/arithmetic.cc
       * 增加MulAAP接口（即合并MulAA + A2P运算），以及相应的gtest；
       * 增加PRZS（随机零分享）接口；
       * 修改P2A协议：random shamir sharing -> public values as sharing；
- libspu/mpc/shamir/boolean.cc
       * 修改B2P协议：-> B2A + A2P
       * 修改B2V协议：-> B2A + A2V
- libspu/mpc/shamir/conversion.cc
       * 用batch_inversion优化rand_bits
       * 利用梅森素数的性质优化rand_bits协议
       * 删除rand_bits_pair协议
       * 利用梅森素数的性质优化solved_bits
       * 新增gen_prefix_mul_share接口，生成用于计算prefix_mult所需的random pairs
       * 利用gen_prefix_mul重新实现prefix_mul协议，测试MsbA接口
       * 利用重新实现的prefix_mul接口优化bit_it_ap协议
       * 优化unbounded_carries协议
       * 优化A2B协议
       * 新增MultAATrunc协议，即定点小数乘法协议
       * 新增MultAAA协议，ATLAS的两层乘法协议
      * 新增ReLU协议，使用ATLAS的两层乘法优化了最后的乘法所需要的通信

Issue Number: Fixed #

## Possible side effects?

- Performance:

- Backward compatibility:
