### PR TITLE
Port radix sort support for unsigned and signed types

### DIFF
--- a/src/libspu/core/type_util.cc
+++ b/src/libspu/core/type_util.cc
@@ -52,6 +52,14 @@ bool isInteger(DataType dtype) {
   }
 }
 
+bool isUInteger(DataType dtype) {
+  switch (dtype) {
+    FOREACH_UINT_DTYPES(CASE)
+    default:
+      return false;
+  }
+}
+
 bool isFixedPoint(DataType dtype) {
   switch (dtype) {
     FOREACH_FXP_DTYPES(CASE)

--- a/src/libspu/core/type_util.h
+++ b/src/libspu/core/type_util.h
@@ -50,6 +50,13 @@ std::ostream& operator<<(std::ostream& os, const Visibility& vtype);
   FN(DT_I64, I64, 64)          \
   FN(DT_U64, U64, 64)
 
+#define FOREACH_UINT_DTYPES(FN) \
+  FN(DT_I1, I1, 1)              \
+  FN(DT_U8, U8, 8)              \
+  FN(DT_U16, U16, 16)           \
+  FN(DT_U32, U32, 32)           \
+  FN(DT_U64, U64, 64)
+
 #define FOREACH_FXP_DTYPES(FN) \
   FN(DT_F16, F16, 16)          \
   FN(DT_F32, F32, 32)          \
@@ -60,6 +67,7 @@ std::ostream& operator<<(std::ostream& os, const Visibility& vtype);
   FOREACH_FXP_DTYPES(FN)
 
 bool isInteger(DataType dtype);
+bool isUInteger(DataType dtype);
 bool isFixedPoint(DataType dtype);
 size_t getWidth(DataType dtype);
 

--- a/src/libspu/core/value.h
+++ b/src/libspu/core/value.h
@@ -80,6 +80,7 @@ class Value final {
   // Get dtype.
   DataType dtype() const { return dtype_; }
   bool isInt() const { return isInteger(dtype()); }
+  bool isUInt() const { return isUInteger(dtype()); }
   bool isFxp() const { return isFixedPoint(dtype()); }
   bool isComplex() const { return imag_.has_value(); }
 

--- a/src/libspu/kernel/hal/permute.h
+++ b/src/libspu/kernel/hal/permute.h
@@ -58,6 +58,10 @@ std::vector<spu::Value> sort1d(SPUContext *ctx,
 //  - direction: sorting order
 //  - num_keys: the number of operands to treat as keys (count from index 0)
 //  - valid_bits: indicates the numeric range of keys for performance hint
+//
+// Important notes:
+//   - for radix sort, the user should ensure that the data has the correct
+//     signed or unsigned type.
 std::vector<spu::Value> simple_sort1d(SPUContext *ctx,
                                       absl::Span<spu::Value const> inputs,
                                       SortDirection direction, int64_t num_keys,


### PR DESCRIPTION
# Pull Request

## What problem does this PR solve?

Issue Number: Fixed #1367

## Possible side effects?

- Performance: Potential changes in sorting performance due to handling both signed and unsigned types.

- Backward compatibility: Maintains compatibility while introducing new functionality for sorting based on data type.

