### PR TITLE
Use asymmetric local truncation for semi2k/aby3 TruncA

### DIFF
--- a/src/libspu/mpc/aby3/arithmetic.cc
+++ b/src/libspu/mpc/aby3/arithmetic.cc
@@ -724,8 +724,7 @@ NdArrayRef TruncA::proc(KernelEvalContext* ctx, const NdArrayRef& in,
       // -arshift(-(b+c))  rounds toward +inf, balancing parties 0/2's
       // arshift(a) which rounds toward -inf.
       const auto sum = ring_add(x1, x2);
-      const auto trunc_asym =
-          ring_neg(ring_arshift(ring_neg(sum), shift_bit));
+      const auto trunc_asym = ring_neg(ring_arshift(ring_neg(sum), shift_bit));
       const auto z1 = ring_sub(trunc_asym, r1);
       comm->sendAsync(0, z1, kBindName());
       return makeAShare(z1, r1, field);

--- a/src/libspu/mpc/aby3/arithmetic.cc
+++ b/src/libspu/mpc/aby3/arithmetic.cc
@@ -720,7 +720,13 @@ NdArrayRef TruncA::proc(KernelEvalContext* ctx, const NdArrayRef& in,
 
     case 1: {
       auto r1 = r_future.get().second;
-      const auto z1 = ring_sub(ring_arshift(ring_add(x1, x2), shift_bit), r1);
+      // Asymmetric truncation of the second half (b+c):
+      // -arshift(-(b+c))  rounds toward +inf, balancing parties 0/2's
+      // arshift(a) which rounds toward -inf.
+      const auto sum = ring_add(x1, x2);
+      const auto trunc_asym =
+          ring_neg(ring_arshift(ring_neg(sum), shift_bit));
+      const auto z1 = ring_sub(trunc_asym, r1);
       comm->sendAsync(0, z1, kBindName());
       return makeAShare(z1, r1, field);
     }

--- a/src/libspu/mpc/semi2k/arithmetic.cc
+++ b/src/libspu/mpc/semi2k/arithmetic.cc
@@ -473,9 +473,18 @@ NdArrayRef TruncA::proc(KernelEvalContext* ctx, const NdArrayRef& x,
 
   // TODO: add truncation method to options.
   if (comm->getWorldSize() == 2) {
-    // SecureML, local truncation.
+    // Asymmetric local truncation:
+    //   rank 0:  x0 >> k                (round toward -inf)
+    //   rank 1: -((-x1) >> k)           (round toward +inf)
+    // Combined rounding is centered around 0, balancing the per-share bias
+    // of the original symmetric SecureML scheme.
     // Ref: Theorem 1. https://eprint.iacr.org/2017/396.pdf
-    return ring_arshift(x, {static_cast<int64_t>(bits)}).as(x.eltype());
+    const Sizes shift = {static_cast<int64_t>(bits)};
+    if (comm->getRank() == 0) {
+      return ring_arshift(x, shift).as(x.eltype());
+    } else {
+      return ring_neg(ring_arshift(ring_neg(x), shift)).as(x.eltype());
+    }
   } else {
     // ABY3, truncation pair method.
     // Ref: Section 5.1.2 https://eprint.iacr.org/2018/403.pdf


### PR DESCRIPTION
Replace symmetric truncation (x0>>k, x1>>k) with asymmetric truncation (x0>>k, -((-x1)>>k)) so the two shares round in opposite directions. This removes the per-share rounding-toward-(-inf) bias of the original truncation, giving an expected error closer to 0.

- semi2k 2PC TruncA: rank 1 now computes -arshift(-x).
- aby3 3PC TruncA: party 1 (which holds b+c) uses -arshift(-(b+c)) while parties 0/2 keep arshift(a) so the two replicated halves remain consistent.

# Pull Request

## What problem does this PR solve?

Issue Number: Fixed #1998 in SecretFlow


