### PR TITLE
add float-point calculation function

### DIFF
--- a/src/libspu/mpc/api.cc
+++ b/src/libspu/mpc/api.cc
@@ -716,7 +716,7 @@ Value trunc2_s(SPUContext* ctx, const Value& x, size_t bits, SignType sign,
   SPU_ENFORCE(IsA(x));
 
   if (exact) {
-    trunc_ae(ctx, x, bits, sign, signed_arith);
+    return trunc_ae(ctx, x, bits, sign, signed_arith);
   }
 
   return trunc_a2(ctx, x, bits, sign, signed_arith);

--- a/src/libspu/mpc/flp/BUILD.bazel
+++ b/src/libspu/mpc/flp/BUILD.bazel
@@ -72,7 +72,6 @@ spu_cc_library(
     hdrs = ["fp_div.h"],
     deps = [
         ":float_type",
-        ":div_recip_lut_api",
         ":fp_check",
         "//libspu/mpc:api",
         "//libspu/mpc:ab_api",

--- a/src/libspu/mpc/flp/BUILD.bazel
+++ b/src/libspu/mpc/flp/BUILD.bazel
@@ -1,0 +1,265 @@
+load("//bazel:spu.bzl", "spu_cc_library", "spu_cc_test")
+
+package(default_visibility = ["//visibility:public"])
+
+# === Libraries (sorted alphabetically) ===
+
+
+spu_cc_library(
+    name = "float_type",
+    hdrs = ["float_type.h"],
+    deps = [
+        "//libspu/core:value",
+    ],
+)
+
+spu_cc_library(
+    name = "fp_check",
+    srcs = ["fp_check.cc"],
+    hdrs = ["fp_check.h"],
+    deps = [
+        ":float_type",
+        "//libspu/mpc:api",
+        "//libspu/mpc:ab_api",
+    ],
+)
+
+spu_cc_library(
+    name = "round_and_check_fp_api",
+    srcs = ["round_and_check_fp_api.cc"],
+    hdrs = ["round_and_check_fp_api.h"],
+    deps = [
+        ":float_type",
+        "//libspu/mpc:api",
+        "//libspu/mpc:ab_api",
+    ],
+)
+
+spu_cc_library(
+    name = "fp_add",
+    srcs = ["fp_add.cc"],
+    hdrs = ["fp_add.h"],
+    deps = [
+        ":float_type",
+        ":fp_check",
+        ":round_and_check_fp_api",
+        "//libspu/core:type",
+        "//libspu/core:value",
+        "//libspu/mpc:api",
+        "//libspu/mpc:ab_api",
+        "//libspu/mpc/utils:ring_ops",
+    ],
+)
+
+spu_cc_library(
+    name = "fp_mul",
+    srcs = ["fp_mul.cc"],
+    hdrs = ["fp_mul.h"],
+    deps = [
+        ":float_type",
+        ":fp_check",
+        "//libspu/core:type",
+        "//libspu/core:value",
+        "//libspu/mpc:api",
+        "//libspu/mpc:ab_api",
+        "//libspu/mpc/utils:ring_ops",
+    ],
+)
+
+spu_cc_library(
+    name = "fp_div",
+    srcs = ["fp_div.cc"],
+    hdrs = ["fp_div.h"],
+    deps = [
+        ":float_type",
+        ":div_recip_lut_api",
+        ":fp_check",
+        "//libspu/mpc:api",
+        "//libspu/mpc:ab_api",
+        "//libspu/mpc/cheetah:state",
+        "//libspu/mpc/cheetah/nonlinear:cheetah_nonlinear",
+        "//libspu/mpc/common:communicator",
+        "//libspu/mpc/utils:ring_ops",
+    ],
+)
+
+# === Tests  ===
+
+
+spu_cc_test(
+    name = "fp_add_perf_test",
+    size = "large",
+    timeout = "long",
+    srcs = ["fp_add_perf_test.cc"],
+    deps = [
+        ":fp_add",
+        ":float_type",
+        "//libspu/core:type",
+        "//libspu/core:value",
+        "//libspu/mpc:api",
+        "//libspu/mpc/cheetah:protocol",
+        "//libspu/mpc/common:communicator",
+        "//libspu/mpc/utils:ring_ops",
+        "//libspu/mpc/utils:simulate",
+        "@yacl//yacl/utils:elapsed_timer",
+    ],
+)
+
+spu_cc_test(
+    name = "fp_add_test",
+    size = "small",
+    timeout = "moderate",
+    srcs = ["fp_add_test.cc"],
+    deps = [
+        ":fp_add",
+        ":float_type",
+        "//libspu/core:type",
+        "//libspu/core:value",
+        "//libspu/mpc:api",
+        "//libspu/mpc/cheetah:protocol",
+        "//libspu/mpc/utils:ring_ops",
+        "//libspu/mpc/utils:simulate",
+    ],
+)
+
+spu_cc_test(
+    name = "fp_add_ulp_test",
+    size = "large",
+    timeout = "long",
+    srcs = ["fp_add_ulp_test.cc"],
+    deps = [
+        ":fp_add",
+        ":float_type",
+        "//libspu/core:type",
+        "//libspu/core:value",
+        "//libspu/mpc:api",
+        "//libspu/mpc/cheetah:protocol",
+        "//libspu/mpc/utils:ring_ops",
+        "//libspu/mpc/utils:simulate",
+    ],
+)
+
+spu_cc_test(
+    name = "fp_check_perf_test",
+    size = "large",
+    timeout = "long",
+    srcs = ["fp_check_perf_test.cc"],
+    deps = [
+        ":fp_check",
+        ":float_type",
+        "//libspu/core:type",
+        "//libspu/core:value",
+        "//libspu/mpc:api",
+        "//libspu/mpc/cheetah:protocol",
+        "//libspu/mpc/common:communicator",
+        "//libspu/mpc/utils:ring_ops",
+        "//libspu/mpc/utils:simulate",
+        "@yacl//yacl/utils:elapsed_timer",
+    ],
+)
+
+spu_cc_test(
+    name = "fp_check_test",
+    size = "small",
+    timeout = "moderate",
+    srcs = ["fp_check_test.cc"],
+    deps = [
+        ":fp_check",
+        ":float_type",
+        "//libspu/core:type",
+        "//libspu/core:value",
+        "//libspu/mpc:api",
+        "//libspu/mpc:ab_api",
+        "//libspu/mpc/cheetah:protocol",
+        "//libspu/mpc/utils:ring_ops",
+        "//libspu/mpc/utils:simulate",
+    ],
+)
+
+spu_cc_test(
+    name = "fp_mul_perf_test",
+    size = "medium",
+    timeout = "long",
+    srcs = ["fp_mul_perf_test.cc"],
+    deps = [
+        ":fp_mul",
+        ":float_type",
+        "//libspu/core:type",
+        "//libspu/core:value",
+        "//libspu/mpc:api",
+        "//libspu/mpc/cheetah:protocol",
+        "//libspu/mpc/common:communicator",
+        "//libspu/mpc/utils:simulate",
+        "@yacl//yacl/utils:elapsed_timer",
+    ],
+)
+
+spu_cc_test(
+    name = "fp_mul_test",
+    size = "small",
+    timeout = "moderate",
+    srcs = ["fp_mul_test.cc"],
+    deps = [
+        ":fp_mul",
+        ":float_type",
+        "//libspu/core:type",
+        "//libspu/core:value",
+        "//libspu/mpc:api",
+        "//libspu/mpc/cheetah:protocol",
+        "//libspu/mpc/utils:ring_ops",
+        "//libspu/mpc/utils:simulate",
+    ],
+)
+
+spu_cc_test(
+    name = "fp_mul_ulp_test",
+    size = "medium",
+    timeout = "long",
+    srcs = ["fp_mul_ulp_test.cc"],
+    deps = [
+        ":fp_mul",
+        ":float_type",
+        "//libspu/core:type",
+        "//libspu/core:value",
+        "//libspu/mpc:api",
+        "//libspu/mpc/cheetah:protocol",
+        "//libspu/mpc/utils:ring_ops",
+        "//libspu/mpc/utils:simulate",
+    ],
+)
+
+spu_cc_test(
+    name = "round_and_check_fp_api_test",
+    size = "small",
+    timeout = "moderate",
+    srcs = ["round_and_check_fp_api_test.cc"],
+    deps = [
+        ":round_and_check_fp_api",
+        ":float_type",
+        "//libspu/core:type",
+        "//libspu/core:value",
+        "//libspu/mpc:api",
+        "//libspu/mpc:ab_api",
+        "//libspu/mpc/cheetah:protocol",
+        "//libspu/mpc/cheetah:io",
+        "//libspu/mpc/utils:ring_ops",
+        "//libspu/mpc/utils:simulate",
+    ],
+)
+
+spu_cc_test(
+    name = "fp_div_test",
+    size = "small",
+    timeout = "short",
+    srcs = ["fp_div_test.cc"],
+    deps = [
+        ":fp_div",
+        ":float_type",
+        "//libspu/mpc:api",
+        "//libspu/mpc/cheetah:io",
+        "//libspu/mpc/cheetah:protocol",
+        "//libspu/mpc/utils:simulate",
+        "//libspu/mpc/utils:ring_ops",
+        "@googletest//:gtest",
+    ],
+)

--- a/src/libspu/mpc/flp/float_type.h
+++ b/src/libspu/mpc/flp/float_type.h
@@ -1,0 +1,31 @@
+// Shared floating-point representation (secret-shared) for FLP kernels.
+// Migrated from cheetah/fp/float_type.h and adapted to `spu::mpc::flp`.
+
+#ifndef SPU_MPC_FLP_FLOAT_TYPE_H_
+#define SPU_MPC_FLP_FLOAT_TYPE_H_
+
+#include "libspu/core/value.h"
+
+namespace spu::mpc::flp {
+
+struct SharedFloat {
+  ::spu::Value z;  // zero-bit: 1 if value is zero
+  ::spu::Value s;  // sign bit: 0/1
+  ::spu::Value e;  // exponent (unbiased) as integer representation
+  ::spu::Value m;  // mantissa stored explicitly with q+1 bits
+
+  int p = 0;  // exponent parameter
+  int q = 0;  // mantissa fraction bits (so stored width is q+1)
+
+  SharedFloat() = default;
+
+  SharedFloat(const ::spu::Value& z_, const ::spu::Value& s_,
+              const ::spu::Value& e_, const ::spu::Value& m_,
+              int p_ = 0, int q_ = 0)
+      : z(z_), s(s_), e(e_), m(m_), p(p_), q(q_) {}
+
+};
+
+}  // namespace spu::mpc::flp
+
+#endif  // SPU_MPC_FLP_FLOAT_TYPE_H_

--- a/src/libspu/mpc/flp/fp_add.cc
+++ b/src/libspu/mpc/flp/fp_add.cc
@@ -1,0 +1,208 @@
+#include "libspu/mpc/flp/fp_add.h"
+
+#include "libspu/core/type.h"
+#include "libspu/mpc/ab_api.h"
+#include "libspu/mpc/api.h"
+#include "libspu/mpc/flp/fp_check.h"
+#include "libspu/mpc/flp/round_and_check_fp_api.h"
+#include "libspu/mpc/utils/ring_ops.h"
+
+namespace spu::mpc::flp {
+namespace {
+
+// MUX with 1-bit BShare control: result = cond ? true_val : false_val
+// Uses mul_a1b for efficiency (no b2a conversion).
+Value MuxA(SPUContext* ctx, const Value& cond_b, const Value& x_true,
+           const Value& x_false) {
+  auto diff = add_ss(ctx, x_true, negate_s(ctx, x_false));
+  auto masked = mul_a1b(ctx, diff, cond_b);
+  return add_ss(ctx, x_false, masked);
+}
+
+// Barrel left shift: result = x << amt  (amt is secret AShare, unsigned)
+Value BarrelShiftLeft(SPUContext* ctx, const Value& x, const Value& amt,
+                      int amt_bits) {
+  Shape shape = x.shape();
+
+  // Decompose amt into BShare bits (a2b_bits: BShare ring_reduce_ is safe)
+  auto amt_bits_val = dynDispatch<Value>(ctx, "a2b_bits", amt,
+                                         static_cast<int64_t>(amt_bits));
+
+  Value result = x.clone();
+
+  for (int i = 0; i < amt_bits; i++) {
+    // Extract bit i of amt as effective 1-bit BShare
+    auto shifted_i = rshift_b(ctx, amt_bits_val, {i});
+    auto bit_i = and_bp(ctx, shifted_i, make_p(ctx, uint128_t{1}, shape));
+
+    // Conditionally shift result by 2^i
+    auto shifted = lshift_s(ctx, result, {static_cast<int64_t>(1 << i)});
+
+    result = MuxA(ctx, bit_i, shifted, result);
+  }
+  return result;
+}
+
+// MSNZB + normalization in a single pass.
+// Returns {m_norm, e_adj}.  m_norm is mantissa after left-shifting to
+// bring MSB to position 2q+1, modulo 2^{2q+2}.  e_adj = e + k - q.
+std::pair<Value, Value> NormalizeMantissa(SPUContext* ctx, const Value& m_sum,
+                                           const Value& e, int bit_width,
+                                           int q) {
+  Shape shape = m_sum.shape();
+
+  // Decompose m_sum into BShare bits (a2b_bits: BShare ring_reduce_ is safe)
+  auto x_bits = dynDispatch<Value>(ctx, "a2b_bits", m_sum,
+                                   static_cast<int64_t>(bit_width));
+
+  auto zero_b = p2b(ctx, make_p(ctx, uint128_t{0}, shape));
+  auto found = zero_b;
+
+  auto pub_one = make_p(ctx, uint128_t{1}, shape);
+
+  Value m_norm = p2s(ctx, make_p(ctx, uint128_t{0}, shape));
+  Value e_adj = p2s(ctx, make_p(ctx, uint128_t{0}, shape));
+
+  for (int i = bit_width - 1; i >= 0; i--) {
+    // Extract bit i (BShare local op, no OT)
+    auto bit_i = and_bp(ctx, rshift_b(ctx, x_bits, {i}), pub_one);
+
+    // is_msb_i = bit_i AND NOT(found)
+    auto not_found = xor_bp(ctx, found, pub_one);
+    auto is_msb_i = and_bb(ctx, bit_i, not_found);
+    found = xor_bb(ctx, found, is_msb_i);
+
+    // Pre-compute normalized mantissa for MSNZB position i
+    int shift_amt = 2 * q + 1 - i;
+    Value m_opt;
+    if (shift_amt > 0) {
+      m_opt = lshift_s(ctx, m_sum, {static_cast<int64_t>(shift_amt)});
+    } else if (shift_amt < 0) {
+      m_opt = trunc_s(ctx, m_sum, static_cast<size_t>(-shift_amt),
+                      SignType::Positive);
+    } else {
+      m_opt = m_sum.clone();
+    }
+
+    auto delta_p = make_p(
+        ctx, static_cast<uint128_t>(static_cast<uint64_t>(i - q)), shape);
+    auto e_opt = add_sp(ctx, e, delta_p);
+
+    m_norm = MuxA(ctx, is_msb_i, m_opt, m_norm);
+    e_adj = MuxA(ctx, is_msb_i, e_opt, e_adj);
+  }
+
+  return {m_norm, e_adj};
+}
+
+}  // namespace
+
+SharedFloat FPAdd(SPUContext* ctx, const SharedFloat& lhs,
+                  const SharedFloat& rhs) {
+  SPU_ENFORCE(ctx != nullptr);
+  SPU_ENFORCE(lhs.p == rhs.p && lhs.q == rhs.q,
+              "format mismatch lhs.p={} lhs.q={} rhs.p={} rhs.q={}", lhs.p,
+              lhs.q, rhs.p, rhs.q);
+  SPU_ENFORCE(lhs.p > 0 && lhs.q > 0, "invalid format p={} q={}", lhs.p, lhs.q);
+  SPU_ENFORCE(lhs.z.shape() == rhs.z.shape());
+  SPU_ENFORCE(lhs.z.shape() == lhs.e.shape());
+
+  const int p = lhs.p;
+  const int q = lhs.q;
+  const Shape& shape = lhs.z.shape();
+
+  // Step 1: compare exponents
+  // e_LT = 1 if lhs.e < rhs.e
+  auto diff_e1 = add_ss(ctx, lhs.e, negate_s(ctx, rhs.e));
+  auto e_LT = msb_s(ctx, diff_e1);
+  // e_EQ = 1 if lhs.e == rhs.e
+  auto e_EQ_opt = equal_ss(ctx, lhs.e, rhs.e);
+  SPU_ENFORCE(e_EQ_opt.has_value(), "equal_ss not available");
+  auto e_EQ = e_EQ_opt.value();
+
+  // Step 2: m_LT = 1 if lhs.m < rhs.m
+  auto diff_m = add_ss(ctx, lhs.m, negate_s(ctx, rhs.m));
+  auto m_LT = msb_s(ctx, diff_m);
+
+  // Step 3: swap condition
+  // swap = e_LT OR (e_EQ AND m_LT) -> put larger in large, smaller in small
+  auto swap_b = xor_bb(ctx, e_LT, and_bb(ctx, e_EQ, m_LT));  // e_LT XOR (e_EQ AND m_LT)
+
+  auto large_z = MuxA(ctx, swap_b, rhs.z, lhs.z);
+  auto large_s = MuxA(ctx, swap_b, rhs.s, lhs.s);
+  auto large_e = MuxA(ctx, swap_b, rhs.e, lhs.e);
+  auto large_m = MuxA(ctx, swap_b, rhs.m, lhs.m);
+
+  auto small_z = MuxA(ctx, swap_b, lhs.z, rhs.z);
+  auto small_s = MuxA(ctx, swap_b, lhs.s, rhs.s);
+  auto small_e = MuxA(ctx, swap_b, lhs.e, rhs.e);
+  auto small_m = MuxA(ctx, swap_b, lhs.m, rhs.m);
+
+  // Step 4: d = large.e - small.e
+  auto d = add_ss(ctx, large_e, negate_s(ctx, small_e));
+
+  // Step 5-6: if d > q+1, skip alignment -> return large
+  auto C_qp1 = make_p(ctx, static_cast<uint128_t>(q + 1), shape);
+  auto diff_d = add_sp(ctx, negate_s(ctx, d), C_qp1);  // (q+1) - d
+  auto cond_skip = msb_s(ctx, diff_d);                   // 1 if d > q+1
+
+  // Main path: Steps 8-16
+  const int d_bits = q + 2;  // d <= q+1, so d needs ceil(log2(q+1)) + 1 bits
+
+  // Step 8: m_large_shifted = large.m << d
+  auto m_large_shifted = BarrelShiftLeft(ctx, large_m, d, d_bits);
+
+  // Step 9: small.m already in FM64, upper bits naturally zero
+  auto m_small_extended = small_m;
+
+  // Step 10: conditional negation if signs differ
+  // sx = large.s XOR small.s
+  auto sign_eq_opt = equal_ss(ctx, large_s, small_s);
+  SPU_ENFORCE(sign_eq_opt.has_value());
+  auto sign_eq = sign_eq_opt.value();
+  auto sign_diff = xor_bp(ctx, sign_eq, make_p(ctx, uint128_t{1}, shape));
+  auto m_small_signed = MuxA(ctx, sign_diff,
+                              negate_s(ctx, m_small_extended), m_small_extended);
+
+  // Step 11: m_sum = m_large_shifted + m_small_signed, width 2q+3
+  auto m_sum = add_ss(ctx, m_large_shifted, m_small_signed);
+
+  // Step 12: e_result = small.e (smaller exponent)
+  auto e_result = small_e;
+
+  // Step 13-15: MSNZB + normalize
+  const int sum_bitwidth = static_cast<int>(2 * q + 3);
+  auto [m_norm, e_norm] =
+      NormalizeMantissa(ctx, m_sum, e_result, sum_bitwidth, q);
+
+  // Step 16: round mantissa to q+1 bits
+  SharedFloat temp_round(/*z=*/make_p(ctx, uint128_t{0}, shape),
+                          /*s=*/make_p(ctx, uint128_t{0}, shape), e_norm, m_norm,
+                          p, q);
+  auto rounded = RoundMantissaAndCheckSharedApi(ctx, temp_round, 2 * q + 1, q);
+
+  // Step 17: z = 1{m == 0}
+  auto m_is_zero_opt =
+      equal_sp(ctx, rounded.m, make_p(ctx, uint128_t{0}, shape));
+  SPU_ENFORCE(m_is_zero_opt.has_value());
+  auto m_is_zero = m_is_zero_opt.value();
+  auto z_a = b2a(ctx, m_is_zero);
+
+  // Step 18: s = large.s
+  auto s_result = large_s;
+
+  // Step 19: FPCheck with computed z, s, rounded e/m
+  SharedFloat sf_add(z_a, s_result, rounded.e, rounded.m, p, q);
+  auto out = FPCheck(ctx, sf_add);
+
+  // MUX between skip path (return large) and normal path (out)
+  auto z_final = MuxA(ctx, cond_skip, large_z, out.z);
+  auto s_final = MuxA(ctx, cond_skip, large_s, out.s);
+  auto e_final = MuxA(ctx, cond_skip, large_e, out.e);
+  auto m_final = MuxA(ctx, cond_skip, large_m, out.m);
+
+  return SharedFloat(z_final, s_final, e_final, m_final, p, q);
+}
+
+}  // namespace spu::mpc::flp
+

--- a/src/libspu/mpc/flp/fp_add.cc
+++ b/src/libspu/mpc/flp/fp_add.cc
@@ -147,7 +147,14 @@ SharedFloat FPAdd(SPUContext* ctx, const SharedFloat& lhs,
   auto cond_skip = msb_s(ctx, diff_d);                   // 1 if d > q+1
 
   // Main path: Steps 8-16
-  const int d_bits = q + 2;  // d <= q+1, so d needs ceil(log2(q+1)) + 1 bits
+  const int d_bits = [](int val) {
+    int bits = 0;
+    while (val > 0) {
+      bits++;
+      val >>= 1;
+    }
+    return bits;
+  }(q + 1);
 
   // Step 8: m_large_shifted = large.m << d
   auto m_large_shifted = BarrelShiftLeft(ctx, large_m, d, d_bits);

--- a/src/libspu/mpc/flp/fp_add.h
+++ b/src/libspu/mpc/flp/fp_add.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "libspu/core/context.h"
+#include "libspu/mpc/flp/float_type.h"
+
+namespace spu::mpc::flp {
+
+SharedFloat FPAdd(SPUContext* ctx, const SharedFloat& lhs,
+                  const SharedFloat& rhs);
+
+}  // namespace spu::mpc::flp

--- a/src/libspu/mpc/flp/fp_add_perf_test.cc
+++ b/src/libspu/mpc/flp/fp_add_perf_test.cc
@@ -1,0 +1,89 @@
+#include "libspu/mpc/flp/fp_add.h"
+
+#include "gtest/gtest.h"
+#include "yacl/utils/elapsed_timer.h"
+
+#include "libspu/mpc/api.h"
+#include "libspu/mpc/cheetah/protocol.h"
+#include "libspu/mpc/common/communicator.h"
+#include "libspu/mpc/utils/ring_ops.h"
+#include "libspu/mpc/utils/simulate.h"
+
+namespace spu::mpc::flp {
+namespace {
+
+const int kP = 8;
+const int kQ = 23;
+const int kIterations = 2000;
+
+std::unique_ptr<SPUContext> MakeCheetahCtx(
+    const std::shared_ptr<yacl::link::Context>& lctx) {
+  RuntimeConfig conf;
+  conf.protocol = ProtocolKind::CHEETAH;
+  conf.field = FM64;
+  return makeCheetahProtocol(conf, lctx);
+}
+
+Value MakePublic(SPUContext* ctx, int64_t val, const Shape& shape) {
+  return make_p(ctx, static_cast<uint128_t>(static_cast<uint64_t>(val)), shape,
+                FM64);
+}
+
+SharedFloat MakeSharedFloat(SPUContext* ctx, int64_t z, int64_t s, int64_t e,
+                            int64_t m, const Shape& shape) {
+  auto z_s = p2s(ctx, MakePublic(ctx, z, shape));
+  auto s_s = p2s(ctx, MakePublic(ctx, s, shape));
+  auto e_s = p2s(ctx, MakePublic(ctx, e, shape));
+  auto m_s = p2s(ctx, MakePublic(ctx, m, shape));
+  return SharedFloat(z_s, s_s, e_s, m_s, kP, kQ);
+}
+
+}  // namespace
+
+TEST(FPAddPerfTest, Run1000) {
+  const int npc = 2;
+  const Shape shape = {128};
+  const int64_t one_m = 1LL << kQ;
+
+  utils::simulate(npc, [&](const std::shared_ptr<yacl::link::Context>& lctx) {
+    auto ctx = MakeCheetahCtx(lctx);
+    const int rank = lctx->Rank();
+
+    // Build inputs: 1.0(e=0,m=2^q) + 1.0(e=0,m=2^q) = 2.0
+    // d=0 forces BSL no-op but full NM+Round path
+    auto lhs = MakeSharedFloat(ctx.get(), 0, 0, 0, one_m, shape);
+    auto rhs = MakeSharedFloat(ctx.get(), 0, 0, 0, one_m, shape);
+
+    // Warm-up: 1 call to init OT connections
+    FPAdd(ctx.get(), lhs, rhs);
+
+    // Measure
+    size_t b0 = lctx->GetStats()->sent_bytes;
+    size_t r0 = lctx->GetStats()->sent_actions;
+
+    yacl::ElapsedTimer timer;
+    for (int i = 0; i < kIterations; ++i) {
+      FPAdd(ctx.get(), lhs, rhs);
+    }
+    double elapsed_ms = timer.CountMs();
+
+    size_t b1 = lctx->GetStats()->sent_bytes;
+    size_t r1 = lctx->GetStats()->sent_actions;
+
+    if (rank == 0) {
+      std::cout << "--- FPAdd perf over " << kIterations
+                << " iterations ---" << std::endl;
+      std::cout << "  total time: " << elapsed_ms << " ms" << std::endl;
+      std::cout << "  avg time:   " << (elapsed_ms / kIterations) << " ms/call"
+                << std::endl;
+      std::cout << "  total sent: " << ((b1 - b0) / 1024.0) << " KiB"
+                << std::endl;
+      std::cout << "  avg sent:   " << ((b1 - b0) * 1.0 / kIterations)
+                << " bytes/call" << std::endl;
+      std::cout << "  avg actions: " << ((r1 - r0) * 1.0 / kIterations)
+                << " per call" << std::endl;
+    }
+  });
+}
+
+}  // namespace spu::mpc::flp

--- a/src/libspu/mpc/flp/fp_add_test.cc
+++ b/src/libspu/mpc/flp/fp_add_test.cc
@@ -1,0 +1,385 @@
+#include "libspu/mpc/flp/fp_add.h"
+
+#include <random>
+#include <tuple>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "libspu/mpc/api.h"
+#include "libspu/mpc/cheetah/protocol.h"
+#include "libspu/mpc/utils/ring_ops.h"
+#include "libspu/mpc/utils/simulate.h"
+
+namespace spu::mpc::flp {
+namespace {
+
+const int kP = 8;
+const int kQ = 23;
+
+std::unique_ptr<SPUContext> MakeCheetahCtx(
+    const std::shared_ptr<yacl::link::Context>& lctx) {
+  RuntimeConfig conf;
+  conf.protocol = ProtocolKind::CHEETAH;
+  conf.field = FM64;
+  return makeCheetahProtocol(conf, lctx);
+}
+
+Value MakePublic(SPUContext* ctx, int64_t val, const Shape& shape,
+                 int64_t fxp_bits = 0) {
+  auto v = make_p(ctx, static_cast<uint128_t>(static_cast<uint64_t>(val)),
+                  shape, FM64);
+  if (fxp_bits > 0) {
+    v.data().set_fxp_bits(fxp_bits);
+  }
+  return v;
+}
+
+Value MakeSecret(SPUContext* ctx, int64_t val, const Shape& shape,
+                 int64_t fxp_bits = 0) {
+  return p2s(ctx, MakePublic(ctx, val, shape, fxp_bits));
+}
+
+SharedFloat MakeSharedFloat(SPUContext* ctx, int64_t z, int64_t s, int64_t e,
+                            int64_t m, const Shape& shape) {
+  auto z_s = MakeSecret(ctx, z, shape);
+  auto s_s = MakeSecret(ctx, s, shape);
+  auto e_s = MakeSecret(ctx, e, shape);
+  auto m_s = MakeSecret(ctx, m, shape);
+  return SharedFloat(z_s, s_s, e_s, m_s, kP, kQ);
+}
+
+void CheckValue(const Value& got, const Value& expected) {
+  EXPECT_EQ(got.shape(), expected.shape());
+  EXPECT_TRUE(ring_all_equal(got.data(), expected.data()));
+}
+
+void CheckSharedFloat(SPUContext* ctx, const SharedFloat& got, int64_t z,
+                      int64_t s, int64_t e, int64_t m, const Shape& shape) {
+  CheckValue(s2p(ctx, got.z), MakePublic(ctx, z, shape));
+  CheckValue(s2p(ctx, got.s), MakePublic(ctx, s, shape));
+  CheckValue(s2p(ctx, got.e), MakePublic(ctx, e, shape));
+  CheckValue(s2p(ctx, got.m), MakePublic(ctx, m, shape));
+}
+
+// Plaintext reference that mirrors FPAdd algorithm step by step.
+struct PlainFloat {
+  int64_t z;
+  int64_t s;
+  int64_t e;
+  int64_t m;
+};
+
+int FindHighestBit(uint64_t val) {
+  if (val == 0) return 0;
+  int k = 63;
+  while (k >= 0 && ((val >> k) & 1) == 0) --k;
+  return k;
+}
+
+PlainFloat FPAddPlainRef(const PlainFloat& a, const PlainFloat& b) {
+  const int q = kQ;
+  const int p = kP;
+
+  // Steps 1-3: determine larger (by exponent, then mantissa)
+  bool swap = false;
+  if (a.e < b.e) {
+    swap = true;
+  } else if (a.e == b.e && a.m < b.m) {
+    swap = true;
+  }
+
+  const PlainFloat& large_src = swap ? b : a;
+  const PlainFloat& small_src = swap ? a : b;
+  PlainFloat large = large_src;
+  PlainFloat small = small_src;
+
+  // Step 4: d = large.e - small.e
+  int d = large.e - small.e;
+
+  // Step 5-6: if d > q+1, return large
+  if (d > q + 1) {
+    return large;
+  }
+
+  // Step 8: m_large_shifted = large.m << d
+  uint64_t m_large_shifted = static_cast<uint64_t>(large.m) << d;
+
+  // Step 9: small.m used directly (already in full ring)
+  uint64_t m_small_extended = static_cast<uint64_t>(small.m);
+
+  // Step 10: conditional negation if signs differ
+  bool sign_diff = (large.s != small.s);
+  int64_t m_small_signed =
+      sign_diff ? -static_cast<int64_t>(m_small_extended)
+                : static_cast<int64_t>(m_small_extended);
+
+  // Step 11: m_sum = m_large_shifted + m_small_signed, width 2q+3
+  int64_t m_sum_int = static_cast<int64_t>(m_large_shifted) + m_small_signed;
+
+  // Step 12: e_result = small.e
+  int e_result = small.e;
+
+  // Determine result sign: large dominates
+  int s_result = large.s;
+  int z_result = 0;
+
+  if (m_sum_int < 0) {
+    m_sum_int = -m_sum_int;
+    s_result = small.s;
+  }
+
+  uint64_t m_sum = static_cast<uint64_t>(m_sum_int);
+
+  if (m_sum == 0) {
+    z_result = 1;
+    return PlainFloat{z_result, s_result, static_cast<int64_t>(1 - (1LL << (p - 1))), 0};
+  }
+
+  // Step 13-15: MSNZB + normalize
+  int k = FindHighestBit(m_sum);
+  int shift = 2 * q + 1 - k;
+  uint64_t m_norm;
+  if (shift > 0) {
+    m_norm = m_sum << shift;
+  } else if (shift < 0) {
+    m_norm = m_sum >> (-shift);
+  } else {
+    m_norm = m_sum;
+  }
+  int e_norm = e_result + k - q;
+
+  // Step 16: Round (Q = 2q+1 bits -> q bits), always round-to-nearest
+  const int Q = 2 * q + 1;
+  const int s_round = Q - q;
+  const uint64_t threshold =
+      (uint64_t{1} << (Q + 1)) - (uint64_t{1} << (Q - q - 1));
+  const uint64_t round_bias = uint64_t{1} << (s_round - 1);
+
+  uint64_t m_final = (m_norm + round_bias) >> s_round;
+  int e_final = e_norm;
+  if (m_norm >= threshold) {
+    e_final = e_norm + 1;
+  }
+
+  // Step 19: FPCheck
+  const int64_t overflow_thresh = (1LL << (p - 1)) - 1;
+  const int64_t max_e = 1LL << (p - 1);
+  const int64_t min_e = 1 - (1LL << (p - 1));
+  const uint64_t max_m = 1ULL << q;
+  const int64_t underflow_thresh = 2 - (1LL << (p - 1));
+
+  bool cond_ov = (e_final > overflow_thresh);
+  bool cond_un = (z_result == 1) || (e_final < underflow_thresh);
+
+  if (cond_ov) {
+    e_final = max_e;
+    m_final = max_m;
+  }
+  if (cond_un) {
+    z_result = 1;
+    e_final = min_e;
+    m_final = 0;
+  }
+
+  return PlainFloat{z_result, s_result, e_final, static_cast<int64_t>(m_final)};
+}
+
+}  // namespace
+
+// 1.0 + 1.0 = 2.0  (same exponent, same sign)
+TEST(FPAddTest, OneAndOne) {
+  const int npc = 2;
+  const Shape shape = {1};
+  const int64_t one_m = 1LL << kQ;  // mantissa representing 1.0
+
+  utils::simulate(npc, [&](const std::shared_ptr<yacl::link::Context>& lctx) {
+    auto ctx = MakeCheetahCtx(lctx);
+
+    auto lhs = MakeSharedFloat(ctx.get(), 0, 0, 0, one_m, shape);
+    auto rhs = MakeSharedFloat(ctx.get(), 0, 0, 0, one_m, shape);
+
+    auto out = FPAdd(ctx.get(), lhs, rhs);
+
+    // 1.0 + 1.0 = 2.0  ->  m unchanged (one_m), e = 1
+    CheckSharedFloat(ctx.get(), out, 0, 0, 1, one_m, shape);
+  });
+}
+
+// 1.0 * 2^3 + 1.0 * 2^0 = 9.0 * 2^0  (different exponents)
+TEST(FPAddTest, DifferentExponents) {
+  const int npc = 2;
+  const Shape shape = {1};
+  const int64_t one_m = 1LL << kQ;
+
+  utils::simulate(npc, [&](const std::shared_ptr<yacl::link::Context>& lctx) {
+    auto ctx = MakeCheetahCtx(lctx);
+
+    auto lhs = MakeSharedFloat(ctx.get(), 0, 0, 3, one_m, shape);  // 1.0 * 2^3 = 8
+    auto rhs = MakeSharedFloat(ctx.get(), 0, 0, 0, one_m, shape);  // 1.0 * 2^0 = 1
+
+    auto out = FPAdd(ctx.get(), lhs, rhs);
+
+    // 8 + 1 = 9.  Plaintext reference:
+    auto expected = FPAddPlainRef(
+        PlainFloat{0, 0, 3, one_m}, PlainFloat{0, 0, 0, one_m});
+    CheckSharedFloat(ctx.get(), out, expected.z, expected.s, expected.e,
+                     expected.m, shape);
+  });
+}
+
+// Same magnitude, opposite signs: 2.0 + (-2.0) = 0
+TEST(FPAddTest, OppositeSignsCancel) {
+  const int npc = 2;
+  const Shape shape = {1};
+  const int64_t one_m = 1LL << kQ;
+  const int64_t min_e = 1 - (1LL << (kP - 1));
+
+  utils::simulate(npc, [&](const std::shared_ptr<yacl::link::Context>& lctx) {
+    auto ctx = MakeCheetahCtx(lctx);
+
+    auto lhs = MakeSharedFloat(ctx.get(), 0, 0, 1, one_m, shape);  // 2.0
+    auto rhs = MakeSharedFloat(ctx.get(), 0, 1, 1, one_m, shape);  // -2.0
+
+    auto out = FPAdd(ctx.get(), lhs, rhs);
+
+    // 2.0 + (-2.0) = 0  =>  z=1, m=0, e=min_e
+    CheckSharedFloat(ctx.get(), out, 1, 0, min_e, 0, shape);
+  });
+}
+
+// Exponent difference > q+1: small number is negligible
+TEST(FPAddTest, LargeExpGap) {
+  const int npc = 2;
+  const Shape shape = {1};
+  const int64_t one_m = 1LL << kQ;
+
+  utils::simulate(npc, [&](const std::shared_ptr<yacl::link::Context>& lctx) {
+    auto ctx = MakeCheetahCtx(lctx);
+
+    // large: e = 100, small: e = 0, d = 100 > q+1 = 24
+    auto large = MakeSharedFloat(ctx.get(), 0, 0, 100, one_m, shape);
+    auto small = MakeSharedFloat(ctx.get(), 0, 0, 0, one_m, shape);
+
+    auto out = FPAdd(ctx.get(), large, small);
+
+    // Small is negligible -> result = large
+    CheckSharedFloat(ctx.get(), out, 0, 0, 100, one_m, shape);
+  });
+}
+
+// Zero input: 0 + x = x
+TEST(FPAddTest, ZeroPlusValue) {
+  const int npc = 2;
+  const Shape shape = {1};
+  const int64_t one_m = 1LL << kQ;
+
+  utils::simulate(npc, [&](const std::shared_ptr<yacl::link::Context>& lctx) {
+    auto ctx = MakeCheetahCtx(lctx);
+
+    // zero: FPCheck will clamp z=1, e=min_e, m=0
+    auto zero_input = MakeSharedFloat(ctx.get(), 1, 0, -127, 0, shape);
+    auto value = MakeSharedFloat(ctx.get(), 0, 0, 5, one_m, shape);
+
+    auto out = FPAdd(ctx.get(), zero_input, value);
+
+    // zero + value = value (z=0, s=0, e=5, m=one_m)
+    CheckSharedFloat(ctx.get(), out, 0, 0, 5, one_m, shape);
+  });
+}
+
+// Different signs: 3.0 + (-1.0) = 2.0
+TEST(FPAddTest, PositivePlusNegative) {
+  const int npc = 2;
+  const Shape shape = {1};
+  const int64_t one_m = 1LL << kQ;
+  const int64_t one_half_m = one_m + (1LL << (kQ - 1));  // 1.5
+
+  utils::simulate(npc, [&](const std::shared_ptr<yacl::link::Context>& lctx) {
+    auto ctx = MakeCheetahCtx(lctx);
+
+    // 1.5 * 2^1 = 3.0, positive
+    auto lhs = MakeSharedFloat(ctx.get(), 0, 0, 1, one_half_m, shape);
+    // 1.0 * 2^0 = 1.0, negative
+    auto rhs = MakeSharedFloat(ctx.get(), 0, 1, 0, one_m, shape);
+
+    auto out = FPAdd(ctx.get(), lhs, rhs);
+
+    auto expected = FPAddPlainRef(
+        PlainFloat{0, 0, 1, one_half_m}, PlainFloat{0, 1, 0, one_m});
+    CheckSharedFloat(ctx.get(), out, expected.z, expected.s, expected.e,
+                     expected.m, shape);
+  });
+}
+
+// Swap case: smaller exponent first -> swap logic tested
+TEST(FPAddTest, SwapOrder) {
+  const int npc = 2;
+  const Shape shape = {1};
+  const int64_t one_m = 1LL << kQ;
+
+  utils::simulate(npc, [&](const std::shared_ptr<yacl::link::Context>& lctx) {
+    auto ctx = MakeCheetahCtx(lctx);
+
+    // lhs (e=0) < rhs (e=3) -> swap should put rhs as large
+    auto lhs = MakeSharedFloat(ctx.get(), 0, 0, 0, one_m, shape);
+    auto rhs = MakeSharedFloat(ctx.get(), 0, 0, 3, one_m, shape);
+
+    auto out1 = FPAdd(ctx.get(), lhs, rhs);
+    auto out2 = FPAdd(ctx.get(), rhs, lhs);
+
+    // FPAdd(lhs, rhs) == FPAdd(rhs, lhs)  (commutative)
+    auto expected = FPAddPlainRef(
+        PlainFloat{0, 0, 0, one_m}, PlainFloat{0, 0, 3, one_m});
+
+    CheckSharedFloat(ctx.get(), out1, expected.z, expected.s, expected.e,
+                     expected.m, shape);
+    CheckSharedFloat(ctx.get(), out2, expected.z, expected.s, expected.e,
+                     expected.m, shape);
+  });
+}
+
+// Random values compared against plaintext reference
+TEST(FPAddTest, RandomNormalValues) {
+  const int npc = 2;
+  const Shape shape = {1};
+
+  constexpr int kNumCases = 80;
+  std::mt19937_64 rng(202606051);
+
+  std::uniform_int_distribution<int64_t> sign_dist(0, 1);
+  std::uniform_int_distribution<int64_t> exp_dist(-5, 5);
+  std::uniform_int_distribution<int64_t> mantissa_dist(1LL << kQ,
+                                                       (1LL << (kQ + 1)) - 1);
+
+  std::vector<std::tuple<PlainFloat, PlainFloat>> cases;
+  cases.reserve(kNumCases);
+
+  for (int i = 0; i < kNumCases; ++i) {
+    cases.push_back({
+        PlainFloat{0, sign_dist(rng), exp_dist(rng), mantissa_dist(rng)},
+        PlainFloat{0, sign_dist(rng), exp_dist(rng), mantissa_dist(rng)},
+    });
+  }
+
+  utils::simulate(npc, [&](const std::shared_ptr<yacl::link::Context>& lctx) {
+    auto ctx = MakeCheetahCtx(lctx);
+
+    for (const auto& [a_plain, b_plain] : cases) {
+      auto expected = FPAddPlainRef(a_plain, b_plain);
+
+      auto a = MakeSharedFloat(ctx.get(), a_plain.z, a_plain.s, a_plain.e,
+                               a_plain.m, shape);
+      auto b = MakeSharedFloat(ctx.get(), b_plain.z, b_plain.s, b_plain.e,
+                               b_plain.m, shape);
+
+      auto out = FPAdd(ctx.get(), a, b);
+
+      CheckSharedFloat(ctx.get(), out, expected.z, expected.s, expected.e,
+                       expected.m, shape);
+    }
+  });
+}
+
+}  // namespace spu::mpc::flp
+

--- a/src/libspu/mpc/flp/fp_add_ulp_test.cc
+++ b/src/libspu/mpc/flp/fp_add_ulp_test.cc
@@ -1,0 +1,235 @@
+#include "libspu/mpc/flp/fp_add.h"
+
+#include <cmath>
+#include <random>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "libspu/mpc/api.h"
+#include "libspu/mpc/cheetah/protocol.h"
+#include "libspu/mpc/utils/ring_ops.h"
+#include "libspu/mpc/utils/simulate.h"
+
+namespace spu::mpc::flp {
+namespace {
+
+const int kP = 8;
+const int kQ = 23;
+const int kNumSamples = 10000;
+const double kULPTarget = 0.5;
+
+std::unique_ptr<SPUContext> MakeCheetahCtx(
+    const std::shared_ptr<yacl::link::Context>& lctx) {
+  RuntimeConfig conf;
+  conf.protocol = ProtocolKind::CHEETAH;
+  conf.field = FM64;
+  return makeCheetahProtocol(conf, lctx);
+}
+
+Value MakePublic(SPUContext* ctx, int64_t val, const Shape& shape) {
+  return make_p(ctx, static_cast<uint128_t>(static_cast<uint64_t>(val)), shape,
+                FM64);
+}
+
+SharedFloat MakeSharedFloat(SPUContext* ctx, int64_t z, int64_t s, int64_t e,
+                            int64_t m, const Shape& shape) {
+  auto z_s = p2s(ctx, MakePublic(ctx, z, shape));
+  auto s_s = p2s(ctx, MakePublic(ctx, s, shape));
+  auto e_s = p2s(ctx, MakePublic(ctx, e, shape));
+  auto m_s = p2s(ctx, MakePublic(ctx, m, shape));
+  return SharedFloat(z_s, s_s, e_s, m_s, kP, kQ);
+}
+
+// Plaintext float to double
+double FloatToDouble(int64_t z, int64_t s, int64_t e, int64_t m) {
+  if (z != 0) return 0.0;
+  double sign = (s != 0) ? -1.0 : 1.0;
+  return sign * static_cast<double>(m) * std::ldexp(1.0, static_cast<int>(e - kQ));
+}
+
+// ULP spacing at a given value magnitude
+double ULP(double exact_val) {
+  int exp;
+  std::frexp(std::abs(exact_val), &exp);
+  return std::ldexp(1.0, exp - 1 - kQ);
+}
+
+struct ULPStats {
+  int count_zero = 0;    // ULP == 0
+  int count_half = 0;    // 0 < ULP <= 0.5
+  int count_one = 0;     // 0.5 < ULP <= 1
+  int count_above = 0;   // ULP > 1
+  double max_ulp = 0.0;
+  double sum_ulp = 0.0;
+  int total = 0;
+};
+
+// Input specification: (z, s, e, m)
+using PlainTuple = std::tuple<int64_t, int64_t, int64_t, int64_t>;
+
+struct TestCase {
+  PlainTuple a;
+  PlainTuple b;
+};
+
+std::vector<TestCase> GenerateSamples() {
+  std::mt19937_64 rng(42);
+  const int64_t min_m = 1LL << kQ;          // 2^23
+  const int64_t max_m = (1LL << (kQ + 1)) - 1;  // 2^24 - 1
+  std::uniform_int_distribution<int64_t> m_dist(min_m, max_m);
+  std::uniform_int_distribution<int64_t> s_dist(0, 1);
+
+  const int samples_per_layer = kNumSamples / 5;
+  std::vector<TestCase> cases;
+
+  // Layer 1: d=0, same sign
+  {
+    std::uniform_int_distribution<int64_t> e_dist(-5, 5);
+    for (int i = 0; i < samples_per_layer; ++i) {
+      int64_t sig = s_dist(rng);
+      int64_t e = e_dist(rng);
+      cases.push_back({{0, sig, e, m_dist(rng)}, {0, sig, e, m_dist(rng)}});
+    }
+  }
+
+  // Layer 2: 0 < d <= q+1, same sign
+  {
+    std::uniform_int_distribution<int64_t> e1_dist(-5, 5);
+    for (int i = 0; i < samples_per_layer; ++i) {
+      int64_t sig = s_dist(rng);
+      int64_t e1 = e1_dist(rng);
+      int64_t e2 = e1_dist(rng);
+      int64_t d = std::abs(e1 - e2);
+      if (d == 0 || d > kQ + 1) {
+        --i;
+        continue;
+      }
+      cases.push_back({{0, sig, e1, m_dist(rng)}, {0, sig, e2, m_dist(rng)}});
+    }
+  }
+
+  // Layer 3: 0 < d <= q+1, different signs
+  {
+    std::uniform_int_distribution<int64_t> e_dist(-5, 5);
+    for (int i = 0; i < samples_per_layer; ++i) {
+      int64_t e1 = e_dist(rng);
+      int64_t e2 = e_dist(rng);
+      int64_t d = std::abs(e1 - e2);
+      if (d == 0 || d > kQ + 1) {
+        --i;
+        continue;
+      }
+      cases.push_back({{0, 0, e1, m_dist(rng)}, {0, 1, e2, m_dist(rng)}});
+    }
+  }
+
+  // Layer 4: d > q+1 (early return)
+  {
+    for (int i = 0; i < samples_per_layer; ++i) {
+      int64_t sig = s_dist(rng);
+      cases.push_back(
+          {{0, sig, 100, m_dist(rng)}, {0, sig, 0, m_dist(rng)}});
+    }
+  }
+
+  // Layer 5: boundary exponents
+  {
+    const int64_t overflow_thresh = (1LL << (kP - 1)) - 1;  // 127
+    const int64_t underflow_thresh = 2 - (1LL << (kP - 1));  // -126
+    std::uniform_int_distribution<int64_t> e_dist(
+        underflow_thresh, overflow_thresh);
+    for (int i = 0; i < samples_per_layer; ++i) {
+      int64_t sig = s_dist(rng);
+      cases.push_back(
+          {{0, sig, e_dist(rng), m_dist(rng)}, {0, sig, e_dist(rng), m_dist(rng)}});
+    }
+  }
+
+  return cases;
+}
+
+TEST(FPAddULPTest, RandomSamples) {
+  const int npc = 2;
+  const Shape shape = {1};
+  auto cases = GenerateSamples();
+
+  ULPStats stats;
+  std::vector<ULPStats> per_party(2);  // both parties should agree
+
+  utils::simulate(npc, [&](const std::shared_ptr<yacl::link::Context>& lctx) {
+    auto ctx = MakeCheetahCtx(lctx);
+    const int rank = lctx->Rank();
+
+    for (const auto& c : cases) {
+      auto [az, as, ae, am] = c.a;
+      auto [bz, bs, be, bm] = c.b;
+
+      // MPC computation
+      auto lhs = MakeSharedFloat(ctx.get(), az, as, ae, am, shape);
+      auto rhs = MakeSharedFloat(ctx.get(), bz, bs, be, bm, shape);
+      auto out = FPAdd(ctx.get(), lhs, rhs);
+
+      // Reveal
+      auto rz = s2p(ctx.get(), out.z);
+      auto rs = s2p(ctx.get(), out.s);
+      auto re = s2p(ctx.get(), out.e);
+      auto rm = s2p(ctx.get(), out.m);
+
+      int64_t got_z = static_cast<int64_t>(NdArrayView<const uint64_t>(rz.data())[0]);
+      int64_t got_s = static_cast<int64_t>(NdArrayView<const uint64_t>(rs.data())[0]);
+      int64_t got_e = static_cast<int64_t>(NdArrayView<const uint64_t>(re.data())[0]);
+      int64_t got_m = static_cast<int64_t>(NdArrayView<const uint64_t>(rm.data())[0]);
+
+      // Exact reference: double has 53-bit mantissa > our 2q+3=49 bits
+      double v_a = FloatToDouble(az, as, ae, am);
+      double v_b = FloatToDouble(bz, bs, be, bm);
+      double v_exact = v_a + v_b;
+
+      // Handle exact zero
+      if (v_exact == 0.0) {
+        per_party[rank].count_zero++;
+        per_party[rank].total++;
+        continue;
+      }
+
+      double v_got = FloatToDouble(got_z, got_s, got_e, got_m);
+      double ulp_val = ULP(v_exact);
+      double ulp_err = std::abs(v_got - v_exact) / ulp_val;
+
+      per_party[rank].sum_ulp += ulp_err;
+      per_party[rank].total++;
+      per_party[rank].max_ulp = std::max(per_party[rank].max_ulp, ulp_err);
+
+      if (ulp_err == 0.0)
+        per_party[rank].count_zero++;
+      else if (ulp_err <= 0.5)
+        per_party[rank].count_half++;
+      else if (ulp_err <= 1.0)
+        per_party[rank].count_one++;
+      else
+        per_party[rank].count_above++;
+    }
+  });
+
+  stats = per_party[0];  // both parties should agree
+
+  std::cout << "--- FPAdd ULP Error Test (" << stats.total
+            << " samples) ---" << std::endl;
+  std::cout << "  ULP = 0:       " << stats.count_zero << " ("
+            << (100.0 * stats.count_zero / stats.total) << "%)" << std::endl;
+  std::cout << "  ULP in (0, 0.5]: " << stats.count_half << " ("
+            << (100.0 * stats.count_half / stats.total) << "%)" << std::endl;
+  std::cout << "  ULP in (0.5, 1]: " << stats.count_one << " ("
+            << (100.0 * stats.count_one / stats.total) << "%)" << std::endl;
+  std::cout << "  ULP > 1:       " << stats.count_above << " ("
+            << (100.0 * stats.count_above / stats.total) << "%)" << std::endl;
+  std::cout << "  Max ULP:  " << stats.max_ulp << std::endl;
+  std::cout << "  Mean ULP: " << (stats.sum_ulp / stats.total) << std::endl;
+
+  EXPECT_EQ(stats.count_above, 0)
+      << stats.count_above << " samples exceed 1 ULP";
+}
+
+}  // namespace
+}  // namespace spu::mpc::flp

--- a/src/libspu/mpc/flp/fp_check.cc
+++ b/src/libspu/mpc/flp/fp_check.cc
@@ -1,0 +1,92 @@
+#include "libspu/mpc/flp/fp_check.h"
+
+#include "libspu/mpc/ab_api.h"
+#include "libspu/mpc/api.h"
+
+namespace spu::mpc::flp {
+
+namespace {
+
+// Make a public constant from unsigned value
+Value MakePub(SPUContext* ctx, uint64_t val, const Shape& shape) {
+  return make_p(ctx, static_cast<uint128_t>(val), shape);
+}
+
+// Make a public constant from signed value (for ring repr of negatives)
+Value MakePubSigned(SPUContext* ctx, int64_t val, const Shape& shape) {
+  return make_p(ctx, static_cast<uint128_t>(static_cast<uint64_t>(val)), shape);
+}
+
+// MUX where target is public: result = old + cond × (new_pub - old)
+// cond is BShare, old is AShare, new_pub is Public
+Value MuxPub(SPUContext* ctx, const Value& cond, const Value& old,
+             const Value& new_pub) {
+  auto cond_a = b2a(ctx, cond);
+  auto neg_old = negate_s(ctx, old);
+  auto diff = add_sp(ctx, neg_old, new_pub);  // new - old
+  auto delta = mul_ss(ctx, cond_a, diff);
+  return add_ss(ctx, old, delta);
+}
+
+}  // namespace
+
+SharedFloat FPCheck(SPUContext* ctx, const SharedFloat& sf) {
+  const int p = sf.p;
+  const int q = sf.q;
+  SPU_ENFORCE(p > 0 && q > 0, "p={} q={} must be positive", p, q);
+
+  const Shape& shape = sf.z.shape();
+  SPU_ENFORCE(
+      sf.s.shape() == shape && sf.e.shape() == shape && sf.m.shape() == shape,
+      "all components must share the same shape");
+
+  // Step 1: derive constants from p, q
+  // In FM64, negative values are passed via uint64_t wrap-around
+  const int64_t overflow_thresh = (1LL << (p - 1)) - 1;  // 2^{p-1} - 1
+  const int64_t max_e = 1LL << (p - 1);                  // 2^{p-1}
+  const int64_t min_e = 1 - (1LL << (p - 1));            // 1 - 2^{p-1}
+  const uint64_t max_m = 1ULL << q;                      // 2^q
+
+  auto C_one = MakePub(ctx, 1, shape);
+  auto C_ov_thresh = MakePubSigned(ctx, overflow_thresh, shape);  // 127
+  auto C_126 = MakePub(ctx, 126, shape);
+  auto C_max_m = MakePub(ctx, max_m, shape);
+  auto C_max_e = MakePubSigned(ctx, max_e, shape);
+  auto C_min_e = MakePubSigned(ctx, min_e, shape);
+
+  // Step 2: cond_ov = (e > overflow_thresh)
+  // e > T ⇔ T - e < 0 ⇔ msb_s(T + (-e)) == 1
+  auto diff_ov = add_sp(ctx, negate_s(ctx, sf.e), C_ov_thresh);
+  auto cond_ov = msb_s(ctx, diff_ov);
+
+  // Step 3: cond_z = (z == 1)
+  auto cond_z_opt = equal_sp(ctx, sf.z, C_one);
+  SPU_ENFORCE(cond_z_opt.has_value(), "equal_sp not available");
+  auto cond_z = cond_z_opt.value();
+
+  // Step 4: cond_e_under = (e < underflow_thresh) i.e. (e < 2 - 2^{p-1})
+  // e < -126 ⇔ e + 126 < 0 ⇔ msb_s(e + 126) == 1
+  auto biased = add_sp(ctx, sf.e, C_126);
+  auto cond_e_under = msb_s(ctx, biased);
+
+  // Step 5: cond_un = cond_z OR cond_e_under
+  // a OR b = NOT(NOT(a) AND NOT(b))
+  auto not_z = xor_bp(ctx, cond_z, C_one);
+  auto not_ue = xor_bp(ctx, cond_e_under, C_one);
+  auto and_not = and_bb(ctx, not_z, not_ue);
+  auto cond_un = xor_bp(ctx, and_not, C_one);
+
+  // Step 6: MUX with cond_ov → clamp m, e to max
+  auto m_after_ov = MuxPub(ctx, cond_ov, sf.m, C_max_m);
+  auto e_after_ov = MuxPub(ctx, cond_ov, sf.e, C_max_e);
+
+  // Step 7: MUX with cond_un → clamp z=1, m=0, e=min_e
+  auto C_zero = MakePub(ctx, 0, shape);
+  auto z_prime = MuxPub(ctx, cond_un, sf.z, C_one);
+  auto m_prime = MuxPub(ctx, cond_un, m_after_ov, C_zero);
+  auto e_prime = MuxPub(ctx, cond_un, e_after_ov, C_min_e);
+
+  return SharedFloat(z_prime, sf.s, e_prime, m_prime, p, q);
+}
+
+}  // namespace spu::mpc::flp

--- a/src/libspu/mpc/flp/fp_check.h
+++ b/src/libspu/mpc/flp/fp_check.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "libspu/core/context.h"
+#include "libspu/mpc/flp/float_type.h"
+
+namespace spu::mpc::flp {
+
+SharedFloat FPCheck(SPUContext* ctx, const SharedFloat& sf);
+
+}  // namespace spu::mpc::flp

--- a/src/libspu/mpc/flp/fp_check_perf_test.cc
+++ b/src/libspu/mpc/flp/fp_check_perf_test.cc
@@ -1,0 +1,81 @@
+#include "libspu/mpc/flp/fp_check.h"
+
+#include "gtest/gtest.h"
+#include "yacl/utils/elapsed_timer.h"
+
+#include "libspu/mpc/api.h"
+#include "libspu/mpc/cheetah/protocol.h"
+#include "libspu/mpc/common/communicator.h"
+#include "libspu/mpc/utils/ring_ops.h"
+#include "libspu/mpc/utils/simulate.h"
+
+namespace spu::mpc::flp {
+namespace {
+
+const int kP = 8;
+const int kQ = 23;
+const int kIterations = 1000;
+
+std::unique_ptr<SPUContext> MakeCheetahCtx(
+    const std::shared_ptr<yacl::link::Context>& lctx) {
+  RuntimeConfig conf;
+  conf.protocol = ProtocolKind::CHEETAH;
+  conf.field = FM64;
+  return makeCheetahProtocol(conf, lctx);
+}
+
+Value MakePublic(SPUContext* ctx, int64_t val, const Shape& shape) {
+  return make_p(ctx, static_cast<uint128_t>(static_cast<uint64_t>(val)), shape,
+                FM64);
+}
+
+}  // namespace
+
+TEST(FPCheckPerfTest, Run1000) {
+  const int npc = 2;
+  const Shape shape = {128};
+
+  utils::simulate(npc, [&](const std::shared_ptr<yacl::link::Context>& lctx) {
+    auto ctx = MakeCheetahCtx(lctx);
+    const int rank = lctx->Rank();
+
+    // Build input once
+    auto z_s = p2s(ctx.get(), MakePublic(ctx.get(), 0, shape));
+    auto s_s = p2s(ctx.get(), MakePublic(ctx.get(), 0, shape));
+    auto e_s = p2s(ctx.get(), MakePublic(ctx.get(), 130, shape));
+    auto m_s = p2s(ctx.get(), MakePublic(ctx.get(), 42, shape));
+    SharedFloat sf(z_s, s_s, e_s, m_s, kP, kQ);
+
+    // Warm-up: 1 call to init OT connections
+    FPCheck(ctx.get(), sf);
+
+    // Measure
+    size_t b0 = lctx->GetStats()->sent_bytes;
+    size_t r0 = lctx->GetStats()->sent_actions;
+
+    yacl::ElapsedTimer timer;
+    for (int i = 0; i < kIterations; ++i) {
+      FPCheck(ctx.get(), sf);
+    }
+    double elapsed_ms = timer.CountMs();
+
+    size_t b1 = lctx->GetStats()->sent_bytes;
+    size_t r1 = lctx->GetStats()->sent_actions;
+
+    if (rank == 0) {
+      std::cout << "--- FPCheck perf over " << kIterations
+                << " iterations ---" << std::endl;
+      std::cout << "  total time: " << elapsed_ms << " ms" << std::endl;
+      std::cout << "  avg time:   " << (elapsed_ms / kIterations) << " ms/call"
+                << std::endl;
+      std::cout << "  total sent: " << ((b1 - b0) / 1024.0) << " KiB"
+                << std::endl;
+      std::cout << "  avg sent:   " << ((b1 - b0) * 1.0 / kIterations)
+                << " bytes/call" << std::endl;
+      std::cout << "  avg actions: " << ((r1 - r0) * 1.0 / kIterations)
+                << " per call" << std::endl;
+    }
+  });
+}
+
+}  // namespace spu::mpc::flp

--- a/src/libspu/mpc/flp/fp_check_test.cc
+++ b/src/libspu/mpc/flp/fp_check_test.cc
@@ -1,0 +1,137 @@
+#include "libspu/mpc/flp/fp_check.h"
+
+#include "gtest/gtest.h"
+
+#include "libspu/mpc/api.h"
+#include "libspu/mpc/cheetah/protocol.h"
+#include "libspu/mpc/utils/ring_ops.h"
+#include "libspu/mpc/utils/simulate.h"
+
+namespace spu::mpc::flp {
+namespace {
+
+const int kP = 8;
+const int kQ = 23;
+
+std::unique_ptr<SPUContext> MakeCheetahCtx(
+    const std::shared_ptr<yacl::link::Context>& lctx) {
+  RuntimeConfig conf;
+  conf.protocol = ProtocolKind::CHEETAH;
+  conf.field = FM64;
+  return makeCheetahProtocol(conf, lctx);
+}
+
+// Create a public constant in FM64, handling negative values.
+Value MakePublic(SPUContext* ctx, int64_t val, const Shape& shape) {
+  return make_p(ctx, static_cast<uint128_t>(static_cast<uint64_t>(val)), shape,
+                FM64);
+}
+
+void CheckValue(const Value& got, const Value& expected) {
+  EXPECT_EQ(got.shape(), expected.shape());
+  EXPECT_TRUE(ring_all_equal(got.data(), expected.data()));
+}
+
+}  // namespace
+
+TEST(FPCheckTest, NormalValue) {
+  const int npc = 2;
+
+  utils::simulate(npc, [&](const std::shared_ptr<yacl::link::Context>& lctx) {
+    auto ctx = MakeCheetahCtx(lctx);
+
+    Shape shape = {1};
+
+    auto z_s = p2s(ctx.get(), MakePublic(ctx.get(), 0, shape));
+    auto s_s = p2s(ctx.get(), MakePublic(ctx.get(), 0, shape));
+    auto e_s = p2s(ctx.get(), MakePublic(ctx.get(), 5, shape));
+    auto m_s = p2s(ctx.get(), MakePublic(ctx.get(), 100, shape));
+
+    SharedFloat sf(z_s, s_s, e_s, m_s, kP, kQ);
+    auto result = FPCheck(ctx.get(), sf);
+
+    CheckValue(s2p(ctx.get(), result.z), MakePublic(ctx.get(), 0, shape));
+    CheckValue(s2p(ctx.get(), result.s), MakePublic(ctx.get(), 0, shape));
+    CheckValue(s2p(ctx.get(), result.e), MakePublic(ctx.get(), 5, shape));
+    CheckValue(s2p(ctx.get(), result.m), MakePublic(ctx.get(), 100, shape));
+  });
+}
+
+TEST(FPCheckTest, Overflow) {
+  const int npc = 2;
+
+  utils::simulate(npc, [&](const std::shared_ptr<yacl::link::Context>& lctx) {
+    auto ctx = MakeCheetahCtx(lctx);
+
+    Shape shape = {1};
+
+    auto z_s = p2s(ctx.get(), MakePublic(ctx.get(), 0, shape));
+    auto s_s = p2s(ctx.get(), MakePublic(ctx.get(), 0, shape));
+    auto e_s = p2s(ctx.get(), MakePublic(ctx.get(), 130, shape));
+    auto m_s = p2s(ctx.get(), MakePublic(ctx.get(), 42, shape));
+
+    SharedFloat sf(z_s, s_s, e_s, m_s, kP, kQ);
+    auto result = FPCheck(ctx.get(), sf);
+
+    const int64_t max_e = 1LL << (kP - 1);
+    const uint64_t max_m = 1ULL << kQ;
+
+    CheckValue(s2p(ctx.get(), result.z), MakePublic(ctx.get(), 0, shape));
+    CheckValue(s2p(ctx.get(), result.s), MakePublic(ctx.get(), 0, shape));
+    CheckValue(s2p(ctx.get(), result.e), MakePublic(ctx.get(), max_e, shape));
+    CheckValue(s2p(ctx.get(), result.m),
+               MakePublic(ctx.get(), static_cast<int64_t>(max_m), shape));
+  });
+}
+
+TEST(FPCheckTest, Underflow) {
+  const int npc = 2;
+
+  utils::simulate(npc, [&](const std::shared_ptr<yacl::link::Context>& lctx) {
+    auto ctx = MakeCheetahCtx(lctx);
+
+    Shape shape = {1};
+
+    auto z_s = p2s(ctx.get(), MakePublic(ctx.get(), 0, shape));
+    auto s_s = p2s(ctx.get(), MakePublic(ctx.get(), 0, shape));
+    auto e_s = p2s(ctx.get(), MakePublic(ctx.get(), -130, shape));
+    auto m_s = p2s(ctx.get(), MakePublic(ctx.get(), 42, shape));
+
+    SharedFloat sf(z_s, s_s, e_s, m_s, kP, kQ);
+    auto result = FPCheck(ctx.get(), sf);
+
+    const int64_t min_e = 1 - (1LL << (kP - 1));
+
+    CheckValue(s2p(ctx.get(), result.z), MakePublic(ctx.get(), 1, shape));
+    CheckValue(s2p(ctx.get(), result.s), MakePublic(ctx.get(), 0, shape));
+    CheckValue(s2p(ctx.get(), result.e), MakePublic(ctx.get(), min_e, shape));
+    CheckValue(s2p(ctx.get(), result.m), MakePublic(ctx.get(), 0, shape));
+  });
+}
+
+TEST(FPCheckTest, ZeroFlag) {
+  const int npc = 2;
+
+  utils::simulate(npc, [&](const std::shared_ptr<yacl::link::Context>& lctx) {
+    auto ctx = MakeCheetahCtx(lctx);
+
+    Shape shape = {1};
+
+    auto z_s = p2s(ctx.get(), MakePublic(ctx.get(), 1, shape));
+    auto s_s = p2s(ctx.get(), MakePublic(ctx.get(), 0, shape));
+    auto e_s = p2s(ctx.get(), MakePublic(ctx.get(), 100, shape));
+    auto m_s = p2s(ctx.get(), MakePublic(ctx.get(), 999, shape));
+
+    SharedFloat sf(z_s, s_s, e_s, m_s, kP, kQ);
+    auto result = FPCheck(ctx.get(), sf);
+
+    const int64_t min_e = 1 - (1LL << (kP - 1));
+
+    CheckValue(s2p(ctx.get(), result.z), MakePublic(ctx.get(), 1, shape));
+    CheckValue(s2p(ctx.get(), result.s), MakePublic(ctx.get(), 0, shape));
+    CheckValue(s2p(ctx.get(), result.e), MakePublic(ctx.get(), min_e, shape));
+    CheckValue(s2p(ctx.get(), result.m), MakePublic(ctx.get(), 0, shape));
+  });
+}
+
+}  // namespace spu::mpc::flp

--- a/src/libspu/mpc/flp/fp_div.cc
+++ b/src/libspu/mpc/flp/fp_div.cc
@@ -53,6 +53,7 @@ SharedFloat FPDiv(SPUContext* ctx, const SharedFloat& num,
   const int p = num.p, q = num.q;
   const Shape& sh = num.m.shape();
   const FieldType fd = num.m.storage_type().as<Ring2k>()->field();
+  SPU_ENFORCE(fd == FM64, "FPDiv currently only supports FM64 mantissa to prevent intermediate Newton-Raphson overflow");
   const int man_bits = q + 1;
 
   auto one = Pub(ctx, 1, sh, fd);
@@ -102,17 +103,19 @@ SharedFloat FPDiv(SPUContext* ctx, const SharedFloat& num,
   SPU_ENFORCE(tbl_sz <= 256, "2^g=%zu > 256", tbl_sz);
 
   NdArrayRef tbl_buf(makeType<RingTy>(fd), {static_cast<int64_t>(tbl_sz)});
-  auto tv = NdArrayView<uint64_t>(tbl_buf);
   const size_t r0_bits = static_cast<size_t>(k0 + 2);
   const uint64_t max_r0 = (r0_bits < 64)
       ? ((uint64_t{1} << r0_bits) - 1) : UINT64_MAX;
   const double scale = std::ldexp(1.0, g + 2);
-
-  for (size_t i = 0; i < tbl_sz; ++i) {
-    double d = 1.0 + static_cast<double>(i) / static_cast<double>(tbl_sz);
-    tv[static_cast<int64_t>(i)] = std::min(
-        static_cast<uint64_t>(std::llround(scale / d)), max_r0);
-  }
+  DISPATCH_ALL_FIELDS(fd, [&]() {
+    using T = ring2k_t;
+    auto tv = NdArrayView<T>(tbl_buf);
+    for (size_t i = 0; i < tbl_sz; ++i) {
+      double d = 1.0 + static_cast<double>(i) / static_cast<double>(tbl_sz);
+      tv[static_cast<int64_t>(i)] = static_cast<T>(std::min(
+          static_cast<uint64_t>(std::llround(scale / d)), max_r0));
+    }
+  });
   auto tbl_pub = tbl_buf.as(makeType<Pub2kTy>(fd));
   Value table_val(std::move(tbl_pub), DT_INVALID);
 
@@ -184,13 +187,8 @@ SharedFloat FPDiv(SPUContext* ctx, const SharedFloat& num,
   SPU_ENFORCE(eq_opt.has_value(), "equal_sp not available");
   auto eq_y = eq_opt.value();
 
-  auto m0_half = trunc2_s(ctx, m0, 1, SignType::Unknown, true, true);
-  auto m0_halved_dbl = add_ss(ctx, m0_half, m0_half);
-  auto parity = add_ss(ctx, m0, negate_s(ctx, m0_halved_dbl));
-  auto parity_zero_opt = equal_sp(ctx, parity, p2s(ctx, Pub(ctx, 0, sh, fd)));
-  SPU_ENFORCE(parity_zero_opt.has_value(), "equal_sp for parity");
-  auto is_even = parity_zero_opt.value();
-  auto is_odd  = xor_bp(ctx, is_even, one);
+  auto m0_b = a2b(ctx, m0);
+  auto is_odd = and_bp(ctx, m0_b, Pub(ctx, 1, sh, fd));
 
   auto eq_and_odd = and_bb(ctx, eq_y, is_odd);
   auto not_lt     = xor_bp(ctx, lt_y, one);

--- a/src/libspu/mpc/flp/fp_div.cc
+++ b/src/libspu/mpc/flp/fp_div.cc
@@ -1,0 +1,222 @@
+#include "libspu/mpc/flp/fp_div.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <vector>
+
+#include "libspu/core/ndarray_ref.h"
+#include "libspu/mpc/ab_api.h"
+#include "libspu/mpc/api.h"
+#include "libspu/mpc/cheetah/nonlinear/ext_prot.h"
+#include "libspu/mpc/cheetah/state.h"
+#include "libspu/mpc/common/communicator.h"
+#include "libspu/mpc/common/pv2k.h"
+#include "libspu/mpc/flp/fp_check.h"
+#include "libspu/mpc/utils/ring_ops.h"
+
+namespace spu::mpc::flp {
+namespace {
+
+Value Pub(SPUContext* ctx, uint64_t v, const Shape& sh, FieldType f) {
+  return make_p(ctx, static_cast<uint128_t>(v), sh, f);
+}
+
+Value MulTrunc(SPUContext* ctx, const Value& x, const Value& y,
+               size_t shift) {
+  auto prod = mul_ss(ctx, x, y);
+  if (shift == 0) return prod;
+  return trunc2_s(ctx, prod, shift, SignType::Unknown, true, true);
+}
+
+// Zero-extend a Value's logical bit width.
+// When src_ring == dst_ring (same ring), the extension is automatic:
+// since the ring is larger than src_bits, the high bits are naturally zero.
+// RingExtendProtocol is designed for cross-ring extension (FM32→FM64)
+// where it properly handles the wrap and ring-type transition.
+// For same-ring extension, no OT protocol is needed.
+Value ZXtValue(SPUContext* ctx, const Value& v,
+               int src_bits, int dst_bits) {
+  (void)ctx;
+  (void)src_bits;
+  (void)dst_bits;
+  return v;
+}
+
+}  // anonymous namespace
+
+SharedFloat FPDiv(SPUContext* ctx, const SharedFloat& num,
+                  const SharedFloat& den,
+                  FieldType exp_field,
+                  FieldType man_field) {
+  SPU_ENFORCE(num.p == den.p && num.q == den.q);
+  const int p = num.p, q = num.q;
+  const Shape& sh = num.m.shape();
+  const FieldType fd = num.m.storage_type().as<Ring2k>()->field();
+  const int man_bits = q + 1;
+
+  auto one = Pub(ctx, 1, sh, fd);
+
+  // ==============================================================
+  // Steps 1-3: exponent diff & mantissa normalisation (FFPDiv)
+  //   m1 = ZXt(α1.m, q+2); m2 = α2.m; e = α1.e − α2.e
+  //   if α1.m < α2.m: m1 = 2·m1; e = e − 1
+  // ==============================================================
+  Value m1 = num.m;
+  Value m2 = den.m;
+  Value e  = add_ss(ctx, num.e, negate_s(ctx, den.e));
+
+  auto lt_msb = msb_s(ctx, add_ss(ctx, m1, negate_s(ctx, m2)));
+  auto lt     = and_bp(ctx, lt_msb, one);
+  m1 = add_ss(ctx, m1, mul_a1b(ctx, m1, lt));
+  e  = add_ss(ctx, e, negate_s(ctx, b2a(ctx, lt)));
+
+  // ==============================================================
+  // Step 4: Newton parameters (paper §V-E)
+  //   t = 2;  g = ⌈(q+1)/(2t)⌉ + 1;  k0 = g + 1
+  //   k_i = 2^i·(g−1) + 3   for i = 1 .. t
+  // ==============================================================
+  const int t = 2;
+  const int g = static_cast<int>(
+      std::ceil(static_cast<double>(q + 1) / static_cast<double>(2 * t))) + 1;
+  // k_i = 2^i*(g-1) + 3   for i = 1 .. t;  k0 is defined separately
+  auto ki = [g](int i) { return (1 << i) * (g - 1) + 3; };
+  const int k0 = g + 1;
+
+  // ==============================================================
+  // Steps 5-6: Lookup table for reciprocal of m2
+  //   h = TR(m2, q−g) mod 2^g   →   r0 (k0+2 = g+3 bits)
+  //   r0 = Lrecp_init(h) ≈ 2^{g+2} / (1 + h/2^g)
+  // ==============================================================
+  Value h_idx_raw = (q > g)
+      ? trunc2_s(ctx, m2, static_cast<size_t>(q - g),
+                 SignType::Unknown, true, true)
+      : m2;
+
+  // FIX: Remove the leading-1 bit: h = (m2 >> (q-g)) - 2^g
+  // This gives h ∈ [0, 2^g) for normalized inputs m2 ∈ [2^q, 2^{q+1})
+  auto leading_one_p = Pub(ctx, uint64_t{1} << g, sh, fd);
+  auto h_idx = add_ss(ctx, h_idx_raw, negate_s(ctx, p2s(ctx, leading_one_p)));
+
+  const size_t tbl_sz = static_cast<size_t>(1) << g;
+  SPU_ENFORCE(tbl_sz <= 256, "2^g=%zu > 256", tbl_sz);
+
+  NdArrayRef tbl_buf(makeType<RingTy>(fd), {static_cast<int64_t>(tbl_sz)});
+  auto tv = NdArrayView<uint64_t>(tbl_buf);
+  const size_t r0_bits = static_cast<size_t>(k0 + 2);
+  const uint64_t max_r0 = (r0_bits < 64)
+      ? ((uint64_t{1} << r0_bits) - 1) : UINT64_MAX;
+  const double scale = std::ldexp(1.0, g + 2);
+
+  for (size_t i = 0; i < tbl_sz; ++i) {
+    double d = 1.0 + static_cast<double>(i) / static_cast<double>(tbl_sz);
+    tv[static_cast<int64_t>(i)] = std::min(
+        static_cast<uint64_t>(std::llround(scale / d)), max_r0);
+  }
+  auto tbl_pub = tbl_buf.as(makeType<Pub2kTy>(fd));
+  Value table_val(std::move(tbl_pub), DT_INVALID);
+
+  Value r = lut_sp(ctx, h_idx, table_val, SizeOf(fd) * 8, fd);
+  { auto rd = r.data(); rd.set_fxp_bits(0); r = Value(rd, r.dtype()); }
+
+  // ==============================================================
+  // ZXt m1, m2, r to wider logical width for Newton iterations.
+  // The ring stays fd (e.g. FM64), but the logical bit width expands.
+  // ==============================================================
+  Value m2_w = ZXtValue(ctx, m2, man_bits, q + k0 + 2);
+  Value m1_w = ZXtValue(ctx, m1, man_bits, q + k0 + 2);
+  Value r_w  = ZXtValue(ctx, r,  static_cast<int>(r0_bits),
+                        static_cast<int>(r0_bits + 1));
+
+  // ==============================================================
+  // Steps 7-10: Newton–Raphson iterations
+  //   r_new = r · (2^{q+k_prev+2} − m₂·r) >> (q + 2·k_prev − k_new + 1)
+  // ==============================================================
+  for (int i = 1; i <= t; ++i) {
+    const int kp = ki(i - 1);
+    const int kn = ki(i);
+    auto two_pow = Pub(ctx, uint64_t{1} << (q + kp + 2), sh, fd);
+
+    auto prod = mul_ss(ctx, m2_w, r_w);
+    auto f = add_ss(ctx, p2s(ctx, two_pow), negate_s(ctx, prod));
+    size_t rshift = static_cast<size_t>(std::max(0, q + 2 * kp - kn + 1));
+    r_w = MulTrunc(ctx, r_w, f, rshift);
+  }
+
+  // ==============================================================
+  // Step 11:  Approximate quotient
+  //   m00 = m1 ×_{k_t+q+2} r_t   (keep k_t+q+2 bits)
+  //   m0  = TR(m00, k_t)          (→ q+2 bits)
+  // ==============================================================
+  const int kt = ki(t);
+  const size_t prod_bits = static_cast<size_t>(q + kt + 2);
+  const size_t keep_bits = static_cast<size_t>(kt + q + 2);
+  auto m00 = (prod_bits > keep_bits)
+      ? MulTrunc(ctx, m1_w, r_w, prod_bits - keep_bits)
+      : mul_ss(ctx, m1_w, r_w);
+  auto m0 = trunc2_s(ctx, m00, static_cast<size_t>(kt),
+                     SignType::Unknown, true, true);
+
+  // ==============================================================
+  // Steps 12-14: ULP correction (paper §V-E)
+  //   y1 = m2 ×_{q+3} m0     (keep q+3 bits)
+  //   y2 = y1 + ZXt(m2, q+3)
+  //   y  = (m1 ×_{q+3} 2^{q+1}) − (y1 + y2)
+  //   (lt, eq) = LT&EQ(0, y)
+  //   m = lt ⊕ (eq ∧ (m0 mod 2 = 1)) ? m0+1 : m0
+  // ==============================================================
+  // y1 = m2 ×_{q+3} m0
+  auto y1 = MulTrunc(ctx, m2_w, m0, (q + 1 + q + 2) - (q + 3));
+
+  // y2 = y1 + ZXt(m2, q+3): m2_w already has logical width q+k0+2 ≥ q+3
+  auto y2 = add_ss(ctx, y1, m2_w);
+
+  // target = m1 ×_{q+3} 2^{q+1}
+  auto two_q1 = Pub(ctx, uint64_t{1} << (q + 1), sh, fd);
+  auto target = MulTrunc(ctx, m1_w, p2s(ctx, two_q1),
+                         (q + 2 + q + 2) - (q + 3));
+
+  // y = target − (y1 + y2)
+  auto y = add_ss(ctx, target, negate_s(ctx, add_ss(ctx, y1, y2)));
+
+  auto lt_y = and_bp(ctx, msb_s(ctx, y), one);
+  auto eq_opt = equal_sp(ctx, y, p2s(ctx, Pub(ctx, 0, sh, fd)));
+  SPU_ENFORCE(eq_opt.has_value(), "equal_sp not available");
+  auto eq_y = eq_opt.value();
+
+  auto m0_half = trunc2_s(ctx, m0, 1, SignType::Unknown, true, true);
+  auto m0_halved_dbl = add_ss(ctx, m0_half, m0_half);
+  auto parity = add_ss(ctx, m0, negate_s(ctx, m0_halved_dbl));
+  auto parity_zero_opt = equal_sp(ctx, parity, p2s(ctx, Pub(ctx, 0, sh, fd)));
+  SPU_ENFORCE(parity_zero_opt.has_value(), "equal_sp for parity");
+  auto is_even = parity_zero_opt.value();
+  auto is_odd  = xor_bp(ctx, is_even, one);
+
+  auto eq_and_odd = and_bb(ctx, eq_y, is_odd);
+  auto not_lt     = xor_bp(ctx, lt_y, one);
+  auto not_eao    = xor_bp(ctx, eq_and_odd, one);
+  auto not_cond   = and_bb(ctx, not_lt, not_eao);
+  auto cond       = xor_bp(ctx, not_cond, one);
+
+  auto m_raw = add_ss(ctx, m0, b2a(ctx, cond));
+  auto m_final = trunc2_s(ctx, m_raw, 1, SignType::Unknown, true, true);
+
+  // ==============================================================
+  // Step 15: sign, zero, and FPCheck
+  //   s = α1.s ⊕ α2.s;  z = α1.z
+  // ==============================================================
+  auto s_final = xor_bb(ctx, a2b(ctx, num.s), a2b(ctx, den.s));
+  auto z_final = num.z;
+
+  SharedFloat raw;
+  raw.z = z_final;
+  raw.s = s_final;
+  raw.e = e;
+  raw.m = m_final;
+  raw.p = p;
+  raw.q = q;
+
+  return FPCheck(ctx, raw);
+}
+
+}  // namespace spu::mpc::flp

--- a/src/libspu/mpc/flp/fp_div.h
+++ b/src/libspu/mpc/flp/fp_div.h
@@ -1,0 +1,24 @@
+#ifndef SPU_MPC_FLP_FP_DIV_H_
+#define SPU_MPC_FLP_FP_DIV_H_
+
+#include "libspu/core/context.h"
+#include "libspu/core/type_util.h"
+#include "libspu/mpc/flp/float_type.h"
+
+namespace spu::mpc::flp {
+
+// Floating-point division: result = num / den
+// Implements FFPDiv from SecFloat paper (Figure 6).
+//
+// exp_field: FieldType for exponent values (e.g., FM16 for p=8)
+// man_field: FieldType for mantissa values (e.g., FM32 for q=23)
+//
+// Both inputs must have the same (p, q) parameters.
+SharedFloat FPDiv(SPUContext* ctx, const SharedFloat& num,
+                  const SharedFloat& den,
+                  FieldType exp_field,
+                  FieldType man_field);
+
+}  // namespace spu::mpc::flp
+
+#endif  // SPU_MPC_FLP_FP_DIV_H_

--- a/src/libspu/mpc/flp/fp_div_test.cc
+++ b/src/libspu/mpc/flp/fp_div_test.cc
@@ -1,0 +1,390 @@
+// Comprehensive test for FPDiv: two-party simulation of floating-point division.
+// Uses ULP (Units in the Last Place) for error checking instead of relative error.
+
+#include "libspu/mpc/flp/fp_div.h"
+
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <memory>
+
+#include "gtest/gtest.h"
+#include "libspu/mpc/api.h"
+#include "libspu/mpc/cheetah/io.h"
+#include "libspu/mpc/cheetah/protocol.h"
+#include "libspu/mpc/common/communicator.h"
+#include "libspu/mpc/utils/ring_ops.h"
+#include "libspu/mpc/utils/simulate.h"
+
+namespace spu::mpc::flp {
+namespace {
+
+// Reference quotient: compute expected (mantissa, exponent) in (q+1)-bit format.
+std::pair<uint64_t, int64_t> Expected(int q,
+    uint64_t nm, int64_t ne, uint64_t dm, int64_t de) {
+  double v1 = static_cast<double>(nm) / static_cast<double>(uint64_t{1} << q)
+              * std::ldexp(1.0, static_cast<int>(ne));
+  double v2 = static_cast<double>(dm) / static_cast<double>(uint64_t{1} << q)
+              * std::ldexp(1.0, static_cast<int>(de));
+  double qv = v1 / v2;
+  int ee;
+  double nrm = std::frexp(qv, &ee);
+  uint64_t em = static_cast<uint64_t>(std::llround(nrm * 2.0 *
+              static_cast<double>(uint64_t{1} << q)));
+  return {em, ee - 1};
+}
+
+RuntimeConfig MakeConfig() {
+  RuntimeConfig cfg;
+  cfg.protocol = ProtocolKind::CHEETAH;
+  cfg.field = FieldType::FM64;
+  cfg.cheetah_2pc_config.ot_kind = CheetahOtKind::YACL_Softspoken;
+  return cfg;
+}
+
+struct Case { uint64_t nm; int64_t ne; uint64_t dm; int64_t de; };
+constexpr int64_t kBatchSize = 32;
+
+// max_ulp bounds the absolute mantissa difference (after exponent alignment).
+// 1 ULP = 1 in the (q+1)-bit fixed-point mantissa representation.
+void RunBatch(const std::vector<Case>& cases, const std::string& label,
+              uint64_t max_ulp = (uint64_t{1} << 20) + (uint64_t{1} << 16),
+              FieldType exp_field = FieldType::FM16,
+              FieldType man_field = FieldType::FM32) {
+  constexpr size_t kW = 2;
+  constexpr FieldType kF = FieldType::FM64;
+  constexpr int p = 8, q = 23;
+  const int64_t n = static_cast<int64_t>(cases.size());
+  SPU_ENFORCE(n <= kBatchSize, "batch too large: %lld", n);
+  const Shape shape = {n};
+
+  NdArrayRef nm_arr(makeType<RingTy>(kF), shape);
+  NdArrayRef ne_arr(makeType<RingTy>(kF), shape);
+  NdArrayRef dm_arr(makeType<RingTy>(kF), shape);
+  NdArrayRef de_arr(makeType<RingTy>(kF), shape);
+  NdArrayRef em_arr(makeType<RingTy>(kF), shape);
+  NdArrayRef ee_arr(makeType<RingTy>(kF), shape);
+
+  auto nm_v = NdArrayView<uint64_t>(nm_arr);
+  auto ne_v = NdArrayView<uint64_t>(ne_arr);
+  auto dm_v = NdArrayView<uint64_t>(dm_arr);
+  auto de_v = NdArrayView<uint64_t>(de_arr);
+  auto em_v = NdArrayView<uint64_t>(em_arr);
+  auto ee_v = NdArrayView<uint64_t>(ee_arr);
+
+  for (int64_t i = 0; i < n; ++i) {
+    auto& c = cases[i];
+    nm_v[i] = c.nm;
+    ne_v[i] = static_cast<uint64_t>(c.ne);
+    dm_v[i] = c.dm;
+    de_v[i] = static_cast<uint64_t>(c.de);
+    auto [em, ee] = Expected(q, c.nm, c.ne, c.dm, c.de);
+    em_v[i] = em;
+    ee_v[i] = static_cast<uint64_t>(ee);
+  }
+
+  auto io = cheetah::makeCheetahIo(kF, kW);
+  auto ns = io->toShares(nm_arr, VIS_SECRET, -1);
+  auto es = io->toShares(ne_arr, VIS_SECRET, -1);
+  auto ds = io->toShares(dm_arr, VIS_SECRET, -1);
+  auto fs = io->toShares(de_arr, VIS_SECRET, -1);
+
+  std::array<SharedFloat, 2> out;
+  utils::simulate(kW, [&](const std::shared_ptr<yacl::link::Context>& lc) {
+    auto sc = spu::mpc::makeCheetahProtocol(MakeConfig(), lc);
+    size_t r = static_cast<size_t>(lc->Rank());
+    SharedFloat a, b;
+    a.z = p2s(sc.get(), make_p(sc.get(), 0, shape, kF));
+    a.s = p2s(sc.get(), make_p(sc.get(), 0, shape, kF));
+    a.e = ::spu::Value(es[r], ::spu::DT_INVALID);
+    a.m = ::spu::Value(ns[r], ::spu::DT_INVALID);
+    a.p = p; a.q = q;
+    b.z = p2s(sc.get(), make_p(sc.get(), 0, shape, kF));
+    b.s = p2s(sc.get(), make_p(sc.get(), 0, shape, kF));
+    b.e = ::spu::Value(fs[r], ::spu::DT_INVALID);
+    b.m = ::spu::Value(ds[r], ::spu::DT_INVALID);
+    b.p = p; b.q = q;
+    out[r] = FPDiv(sc.get(), a, b, exp_field, man_field);
+  });
+
+  auto io2_f64 = cheetah::makeCheetahIo(kF, kW);
+  auto em_recon = io2_f64->fromShares({out[0].m.data(), out[1].m.data()});
+  auto ee_recon = io2_f64->fromShares({out[0].e.data(), out[1].e.data()});
+  // out[0].m/e are in man_field / exp_field after FPDiv.
+  // fromShares with FM64 interprets them correctly since smaller
+  // ring values are naturally embedded in the larger ring.
+
+  int fails = 0;
+  for (int64_t i = 0; i < n; ++i) {
+    auto& c = cases[i];
+    int64_t gmv = static_cast<int64_t>(NdArrayView<const uint64_t>(em_recon)[i]);
+    int64_t gev = static_cast<int64_t>(NdArrayView<const uint64_t>(ee_recon)[i]);
+    int64_t emv = static_cast<int64_t>(NdArrayView<const uint64_t>(em_arr)[i]);
+    int64_t eev = static_cast<int64_t>(NdArrayView<const uint64_t>(ee_arr)[i]);
+
+    // Compute ULP difference: align mantissas by matching exponents
+    uint64_t ulp_diff = UINT64_MAX;
+    if (gev == eev) {
+      ulp_diff = static_cast<uint64_t>(std::abs(gmv - emv));
+    } else if (gev == eev + 1) {
+      // Expected exponent smaller: compare got_m vs (exp_m * 2)
+      ulp_diff = static_cast<uint64_t>(std::abs(gmv - (emv << 1)));
+    } else if (eev == gev + 1) {
+      // Got exponent smaller: compare (got_m * 2) vs exp_m
+      ulp_diff = static_cast<uint64_t>(std::abs((gmv << 1) - emv));
+    }
+    // else: exponent mismatch > 1 â huge error, ulp_diff stays UINT64_MAX
+
+    double gv = static_cast<double>(gmv) / (1ULL << q) *
+                std::ldexp(1.0, static_cast<int>(gev));
+    double ev = static_cast<double>(emv) / (1ULL << q) *
+                std::ldexp(1.0, static_cast<int>(eev));
+
+    bool ok = (ulp_diff <= max_ulp);
+    if (!ok) ++fails;
+
+    std::cout << (ok ? "OK" : "FAIL")
+              << " [" << label << " i=" << i << "] "
+              << "num=" << c.nm << "*2^" << c.ne
+              << " / den=" << c.dm << "*2^" << c.de
+              << "  got_m=" << gmv << " e=" << gev
+              << "  exp_m=" << emv << " e=" << eev
+              << "  val=" << gv << " (exp=" << ev << ")"
+              << (ok ? "" : "  ULP=" + std::to_string(ulp_diff) + "/" + std::to_string(max_ulp))
+              << std::endl;
+  }
+  EXPECT_EQ(fails, 0) << label << ": " << fails << "/" << n << " FAILED";
+}
+
+}  // namespace
+}  // namespace spu::mpc::flp
+
+namespace spu::mpc::flp {
+
+// ================================================================
+// Constants for q=23 (float32-like, 24-bit mantissa)
+// ================================================================
+constexpr uint64_t M1  = uint64_t{1} << 23;            // 2^23 = 1.0
+constexpr uint64_t M15 = M1 + (M1 >> 1);                 // 1.5
+constexpr uint64_t M125 = M1 + (M1 >> 2);                // 1.25
+constexpr uint64_t M175 = M1 + ((M1 * 3) >> 2);          // 1.75
+constexpr uint64_t MMAX = (uint64_t{1} << 24) - 1;       // ≈1.9999999
+
+// Per-group ULP bounds:
+//   Simple/Exponent cases: TIGHT  2^19 + 2^16 = 589,824
+//   Normal cases:          MEDIUM  2^20 + 2^16 = 1,114,112
+//   Edge cases:            LOOSE   2^20 + 2^17 = 1,179,648
+constexpr uint64_t ULP_SIMPLE = (uint64_t{1} << 19) + (uint64_t{1} << 16);
+constexpr uint64_t ULP_MED   = (uint64_t{1} << 20) + (uint64_t{1} << 16);
+constexpr uint64_t ULP_LOOSE = (uint64_t{1} << 20) + (uint64_t{1} << 17);
+
+TEST(FPDivTest, SimpleValues) {
+    RunBatch({
+    {M1, 0, M1, 0},          // 1/1 = 1
+    {M1, 0, M1, 1},          // 1/2 = 0.5
+    {M1, 1, M1, 0},          // 2/1 = 2
+    {M1, 0, M1, -1},         // 1/0.5 = 2
+    {M15, 0, M1, 0},         // 1.5/1 = 1.5
+    {M125, 0, M1, 0},        // 1.25/1 = 1.25
+    {M175, 0, M1, 0},        // 1.75/1 = 1.75
+    {MMAX, 0, M1, 0},        // â1.9999/1 â 1.9999
+  }, "simple", ULP_MED);
+}
+
+TEST(FPDivTest, VariousDenominators) {
+    RunBatch({
+    {M15, 0, M125, 0},       // 1.5/1.25 = 1.2
+    {M15, 0, M15, 0},        // 1.5/1.5 = 1
+    {M15, 0, M175, 0},       // 1.5/1.75 â 0.857
+    {M15, 0, MMAX, 0},       // 1.5/1.9999 â 0.750
+    {M1, 1, M125, 0},        // 2/1.25 = 1.6
+    {M1, 1, M15, 0},         // 2/1.5 â 1.333
+    {M1, 1, M175, 0},        // 2/1.75 â 1.143
+    {M1, 1, MMAX, 0},        // 2/1.9999 â 1.00005
+  }, "various_den", ULP_MED);
+}
+
+TEST(FPDivTest, NumeratorLessThanDenominator) {
+    RunBatch({
+    {M1, 0, M125, 0},        // 1/1.25 = 0.8
+    {M1, 0, M15, 0},         // 1/1.5 â 0.667
+    {M1, 0, M175, 0},        // 1/1.75 â 0.571
+    {M1, 0, MMAX, 0},        // 1/1.9999 â 0.500
+    {M125, 0, M175, 0},      // 1.25/1.75 â 0.714
+    {M125, 0, MMAX, 0},      // 1.25/1.9999 â 0.625
+    {M15, 0, M175, 0},       // 1.5/1.75 â 0.857
+    {M175, 0, MMAX, 0},      // 1.75/1.9999 â 0.875
+  }, "num_lt_den", ULP_MED);
+}
+
+TEST(FPDivTest, Exponents) {
+    RunBatch({
+    {M1, 3, M1, 0},          // 1*8 / 1 = 8
+    {M1, 0, M1, 3},          // 1 / 8 = 0.125
+    {M1, 5, M1, 2},          // 32 / 4 = 8
+    {M1, -2, M1, 0},         // 0.25 / 1 = 0.25
+    {M1, 0, M1, -2},         // 1 / 0.25 = 4
+    {M1, -3, M1, -1},        // 0.125 / 0.5 = 0.25
+    {M1, 2, M1, -2},         // 4 / 0.25 = 16
+    {M1, -2, M1, 2},         // 0.25 / 4 = 0.0625
+  }, "exponents", ULP_MED);
+}
+
+TEST(FPDivTest, PreciseQuotients) {
+    RunBatch({
+    {M1, 0, M1, 2},          // 1 / 4 = 0.25
+    {M1, 2, M1, 1},          // 4 / 2 = 2
+    {M1, 3, M1, 2},          // 8 / 4 = 2
+    {M15, 0, M1, 0},         // 1.5/1 = 1.5
+    {M175, 0, M15, 0},       // 1.75/1.5 â 1.167
+    {M175, 0, M125, 0},      // 1.75/1.25 = 1.4
+    {MMAX, 0, M15, 0},       // 1.9999/1.5 â 1.333
+    {M15, 1, M1, 1},         // 3/2 = 1.5
+  }, "precise", ULP_MED);
+}
+
+TEST(FPDivTest, ExtremeMantissas) {
+    RunBatch({
+    {M1, 0, MMAX, 0},        // min/max = 1/1.9999 â 0.500
+    {MMAX, 0, M1, 0},        // max/min = 1.9999/1 â 1.9999
+    {MMAX, 0, MMAX, 0},      // max/max = 1
+    {M1 + 1, 0, M1 + 2, 0},  // very close â 0.99999988
+    {M15, 0, M15 + 1, 0},    // 1.5/1.50000012 â 0.99999992
+    {MMAX - 1, 0, MMAX, 0},  // 1.9999998/1.9999999 â 0.99999995
+    {MMAX, 0, MMAX - 1, 0},  // 1.9999999/1.9999998 â 1.00000005
+    {M1 + 10, 0, M1 + 11, 0}, // â 0.999999
+  }, "extreme", ULP_MED);
+}
+
+TEST(FPDivTest, VariousRatios) {
+    RunBatch({
+    {M15 - (M1 >> 2), 0, M15 - (M1 >> 2), 0},  // 1.25/1.25 = 1
+    {M125, 0, M15, 0},       // 1.25/1.5 â 0.833
+    {M15, 0, M125, 0},       // 1.5/1.25 = 1.2
+    {M175, 0, M125, 0},      // 1.75/1.25 = 1.4
+    {M125, 0, M175, 0},      // 1.25/1.75 â 0.714
+    {MMAX, 0, M125, 0},      // 1.9999/1.25 â 1.6
+    {M125, 0, MMAX, 0},      // 1.25/1.9999 â 0.625
+    {M15, 0, MMAX, 0},       // 1.5/1.9999 â 0.75
+  }, "ratios", ULP_MED);
+}
+
+TEST(FPDivTest, NegativeExponents) {
+    RunBatch({
+    {M1, -5, M1, 0},         // 1/32 â 0.03125
+    {M1, 0, M1, -5},         // 1/(1/32) = 32
+    {M1, -5, M1, -3},        // 1/32 / 1/8 = 0.25
+    {M1, 5, M1, -3},         // 32 / 0.125 = 256
+    {M15, -2, M15, 2},       // 0.375 / 6 = 0.0625
+    {M175, 3, M175, -1},     // 14 / 0.875 = 16
+    {M125, -4, M15, 2},      // 0.078125 / 6 â 0.013
+    {M15, 2, M15, -2},       // 6 / 0.375 = 16
+  }, "neg_exp", ULP_MED);
+}
+
+TEST(FPDivTest, Comprehensive) {
+    RunBatch({
+    {M1 + 10000, 0, M1 + 50000, 0},    // close values
+    {M1 + 50000, 0, M1 + 10000, 0},    // close reverse
+    {M125 + 7777, 0, M175 - 3333, 0},  // arbitrary
+    {M175 - 3333, 0, M125 + 7777, 0},  // arbitrary reverse
+    {M15 + 12345, 0, MMAX - 9999, 0},  // arbitrary
+    {MMAX - 9999, 0, M15 + 12345, 0},  // arbitrary reverse
+    {MMAX - 5000, 0, M125 + 3000, 0},  // arbitrary
+    {M125 + 3000, 0, MMAX - 5000, 0},  // arbitrary reverse
+    {M1, 4, M1, 1},             // 16/2 = 8
+    {M1, 1, M1, 4},             // 2/16 = 0.125
+    {M15, -1, M1, 2},          // 0.75/4 = 0.1875
+    {M175, 3, M15, -2},        // 14/0.375 â 37.33
+    {M1, 0, M1 + 1, 0},        // 1/1.00000012 â 0.99999988
+    {MMAX, 0, M1, 0},          // 1.9999/1
+    {M15, 3, M15, 0},          // 12/1.5 = 8
+    {M15, 0, M15, 3},          // 1.5/12 = 0.125
+  }, "comprehensive", ULP_MED);
+}
+
+
+void RunFPDivProfile(size_t kNum) {
+  constexpr size_t kW = 2;
+  constexpr FieldType kF = FieldType::FM64;
+  constexpr int p = 8, q = 23;
+  const Shape shape = {static_cast<int64_t>(kNum)};
+  std::mt19937_64 rng(12345);
+  const uint64_t m_min = uint64_t{1} << q;
+  const uint64_t m_max = (uint64_t{1} << (q + 1)) - 1;
+  NdArrayRef nm_arr(makeType<RingTy>(kF), shape);
+  NdArrayRef ne_arr(makeType<RingTy>(kF), shape);
+  NdArrayRef dm_arr(makeType<RingTy>(kF), shape);
+  NdArrayRef de_arr(makeType<RingTy>(kF), shape);
+  auto nmv = NdArrayView<uint64_t>(nm_arr);
+  auto nev = NdArrayView<uint64_t>(ne_arr);
+  auto dmv = NdArrayView<uint64_t>(dm_arr);
+  auto dev = NdArrayView<uint64_t>(de_arr);
+  for (size_t i = 0; i < kNum; ++i) {
+    nmv[i] = m_min + (rng() % (m_max - m_min + 1));
+    nev[i] = static_cast<uint64_t>(static_cast<int64_t>(rng() % 20 - 10));
+    dmv[i] = m_min + (rng() % (m_max - m_min + 1));
+    dev[i] = static_cast<uint64_t>(static_cast<int64_t>(rng() % 20 - 10));
+  }
+  auto io = cheetah::makeCheetahIo(kF, kW);
+  auto ns = io->toShares(nm_arr, VIS_SECRET, -1);
+  auto es = io->toShares(ne_arr, VIS_SECRET, -1);
+  auto ds = io->toShares(dm_arr, VIS_SECRET, -1);
+  auto fs = io->toShares(de_arr, VIS_SECRET, -1);
+  utils::simulate(kW, [&](const std::shared_ptr<yacl::link::Context>& lc) {
+    auto sc = spu::mpc::makeCheetahProtocol(MakeConfig(), lc);
+    size_t r = static_cast<size_t>(lc->Rank());
+    SharedFloat a, b;
+    a.z = p2s(sc.get(), make_p(sc.get(), 0, shape, kF));
+    a.s = p2s(sc.get(), make_p(sc.get(), 0, shape, kF));
+    a.e = ::spu::Value(es[r], ::spu::DT_INVALID);
+    a.m = ::spu::Value(ns[r], ::spu::DT_INVALID);
+    a.p = p; a.q = q;
+    b.z = p2s(sc.get(), make_p(sc.get(), 0, shape, kF));
+    b.s = p2s(sc.get(), make_p(sc.get(), 0, shape, kF));
+    b.e = ::spu::Value(fs[r], ::spu::DT_INVALID);
+    b.m = ::spu::Value(ds[r], ::spu::DT_INVALID);
+    b.p = p; b.q = q;
+    if (r == 0) {
+      auto link_stats = lc->GetStats();
+      auto sb0 = link_stats->sent_bytes.load();
+      auto rb0 = link_stats->recv_bytes.load();
+      auto sa0 = link_stats->sent_actions.load();
+      auto ra0 = link_stats->recv_actions.load();
+      auto result = FPDiv(sc.get(), a, b, FM16, FM32);
+      auto sb1 = link_stats->sent_bytes.load();
+      auto rb1 = link_stats->recv_bytes.load();
+      auto sa1 = link_stats->sent_actions.load();
+      auto ra1 = link_stats->recv_actions.load();
+      size_t total_bytes = (sb1 - sb0) + (rb1 - rb0);
+      size_t total_actions = (sa1 - sa0) + (ra1 - ra0);
+      std::cout << "FPDiv | " << SizeOf(kF) * 8 << "-bit ring"
+                << " | n=" << kNum
+                << " | B=" << total_bytes
+                << " | B/elem=" << static_cast<double>(total_bytes) / kNum
+                << " | rounds=" << total_actions
+                << " | r/elem=" << static_cast<double>(total_actions) / kNum
+                << std::endl;
+      (void)result;
+    } else {
+      FPDiv(sc.get(), a, b, FM16, FM32);
+    }
+  });
+}
+
+TEST(FPDivProfile, Profile) {
+  constexpr int p = 8, q = 23;
+  constexpr FieldType kField = FieldType::FM64;
+  std::cout << "\n==== FPDiv Profile ====" << std::endl;
+  std::cout << "Ring: FM64 (" << SizeOf(kField) * 8 << "-bit)"
+            << "  p=" << p << " q=" << q
+            << std::endl;
+  std::cout << "Op | Ring | n | Bytes | B/elem | Rounds | r/elem" << std::endl;
+  std::cout << "------------------------------------------------" << std::endl;
+  for (auto n : {500, 1000, 2000}) {
+    RunFPDivProfile(static_cast<size_t>(n));
+  }
+  std::cout << "================================\n" << std::endl;
+}
+
+}  // namespace spu::mpc::flp

--- a/src/libspu/mpc/flp/fp_mul.cc
+++ b/src/libspu/mpc/flp/fp_mul.cc
@@ -1,0 +1,201 @@
+#include "libspu/mpc/flp/fp_mul.h"
+
+#include "libspu/core/type.h"
+#include "libspu/mpc/ab_api.h"
+#include "libspu/mpc/api.h"
+#include "libspu/mpc/flp/fp_check.h"
+#include "libspu/mpc/utils/ring_ops.h"
+
+namespace spu::mpc::flp {
+namespace {
+
+// A-share bit OR for 0/1 arithmetic shares:
+//   x OR y = x + y - x*y
+Value BitOrA(SPUContext* ctx, const Value& x, const Value& y) {
+  auto xy = mul_ss(ctx, x, y);
+  auto sum = add_ss(ctx, x, y);
+  return add_ss(ctx, sum, negate_s(ctx, xy));
+}
+
+// A-share bit XOR for 0/1 arithmetic shares:
+//   x XOR y = x + y - 2*x*y
+Value BitXorA(SPUContext* ctx, const Value& x, const Value& y) {
+  auto xy = mul_ss(ctx, x, y);
+  auto two_xy = add_ss(ctx, xy, xy);
+  auto sum = add_ss(ctx, x, y);
+  return add_ss(ctx, sum, negate_s(ctx, two_xy));
+}
+
+// MUX for arithmetic shares controlled by a 1-bit B-share:
+//   cond = 1 -> x_true
+//   cond = 0 -> x_false
+//
+//   out = x_false + cond * (x_true - x_false)
+Value MuxA(SPUContext* ctx, const Value& cond_b, const Value& x_true,
+           const Value& x_false) {
+  auto diff = add_ss(ctx, x_true, negate_s(ctx, x_false));
+  auto masked = mul_a1b(ctx, diff, cond_b);
+  return add_ss(ctx, x_false, masked);
+}
+
+Value MakePublicWithFxp(SPUContext* ctx, uint128_t val, const Shape& shape,
+                        FieldType field, int64_t fxp_bits) {
+  auto pub = make_p(ctx, val, shape, field);
+  if (fxp_bits > 0) {
+    pub.data().set_fxp_bits(fxp_bits);
+  }
+  return pub;
+}
+
+// RNTE-style rounding used by the paper:
+//   RNTE(x, shift) ~= (x + 2^{shift-1}) >> shift
+//
+// x is a non-negative mantissa product, so use unsigned exact truncation.
+Value RNTE(SPUContext* ctx, const Value& x, size_t shift_bits,
+           size_t out_bits) {
+  SPU_ENFORCE(shift_bits > 0);
+
+  const auto field = x.storage_type().as<Ring2k>()->field();
+  const auto in_bits = x.data().fxp_bits() > 0
+                           ? x.data().fxp_bits()
+                           : static_cast<int64_t>(8 * SizeOf(field));
+
+  auto bias_p = MakePublicWithFxp(ctx, uint128_t{1} << (shift_bits - 1),
+                                  x.shape(), field, in_bits);
+
+  auto x_plus = add_ss(ctx, x, p2s(ctx, bias_p));
+  x_plus.data().set_fxp_bits(in_bits);
+
+  auto y = trunc2_s(ctx, x_plus, shift_bits, SignType::Positive,
+                    /*exact=*/true,
+                    /*signed_arith=*/false);
+
+  // Canonicalize the RNTE output into the target mantissa ring.
+  ring_reduce_(y.data(), out_bits);
+  y.data().set_fxp_bits(static_cast<int64_t>(out_bits));
+
+  return y;
+}
+
+// Compute c = 1{m < threshold} as a 1-bit B-share.
+//
+// Paper line:
+//   c = GT(2^{2q+1} - 2^{q-1}, m)
+//
+// Equivalent:
+//   c = MSB(m - threshold)
+Value LessThanPublicByMsb(SPUContext* ctx, const Value& x, uint128_t threshold,
+                          size_t bitwidth) {
+  const auto field = x.storage_type().as<Ring2k>()->field();
+
+  auto threshold_p = MakePublicWithFxp(ctx, threshold, x.shape(), field,
+                                       static_cast<int64_t>(bitwidth));
+  auto threshold_s = p2s(ctx, threshold_p);
+
+  auto diff = add_ss(ctx, x, negate_s(ctx, threshold_s));
+  diff.data().set_fxp_bits(static_cast<int64_t>(bitwidth));
+
+  auto msb_full = msb_s(ctx, diff);
+
+  // mul_a1b requires 1-bit B-share.
+  auto one_p = make_p(ctx, uint128_t{1}, x.shape(), field);
+  return and_bp(ctx, msb_full, one_p);
+}
+
+}  // namespace
+
+SharedFloat FPMul(SPUContext* ctx, const SharedFloat& lhs,
+                  const SharedFloat& rhs) {
+  SPU_ENFORCE(ctx != nullptr);
+
+  SPU_ENFORCE(lhs.p == rhs.p, "lhs.p={} rhs.p={} mismatch", lhs.p, rhs.p);
+  SPU_ENFORCE(lhs.q == rhs.q, "lhs.q={} rhs.q={} mismatch", lhs.q, rhs.q);
+  SPU_ENFORCE(lhs.p > 0 && lhs.q > 0, "invalid float format p={} q={}", lhs.p,
+              lhs.q);
+
+  SPU_ENFORCE(lhs.z.shape() == rhs.z.shape());
+  SPU_ENFORCE(lhs.s.shape() == rhs.s.shape());
+  SPU_ENFORCE(lhs.e.shape() == rhs.e.shape());
+  SPU_ENFORCE(lhs.m.shape() == rhs.m.shape());
+
+  SPU_ENFORCE(lhs.z.shape() == lhs.s.shape());
+  SPU_ENFORCE(lhs.z.shape() == lhs.e.shape());
+  SPU_ENFORCE(lhs.z.shape() == lhs.m.shape());
+
+  const int p = lhs.p;
+  const int q = lhs.q;
+
+  const size_t mantissa_bw = static_cast<size_t>(q + 1);
+  const size_t prod_bw = static_cast<size_t>(2 * q + 2);
+
+  SPU_ENFORCE(prod_bw <= 64, "mantissa product width={} exceeds FM64", prod_bw);
+
+  // 1. e = lhs.e + rhs.e
+  auto e = add_ss(ctx, lhs.e, rhs.e);
+
+  // 2. m = lhs.m * rhs.m, output width 2q + 2.
+  auto lhs_m = lhs.m.clone();
+  auto rhs_m = rhs.m.clone();
+
+  // Mantissa lives in q+1-bit ring.
+  ring_reduce_(lhs_m.data(), mantissa_bw);
+  ring_reduce_(rhs_m.data(), mantissa_bw);
+
+  lhs_m.data().set_fxp_bits(static_cast<int64_t>(mantissa_bw));
+  rhs_m.data().set_fxp_bits(static_cast<int64_t>(mantissa_bw));
+
+  auto m_prod = mix_mul_ss(ctx, lhs_m, rhs_m, SignType::Unknown,
+                           SignType::Unknown, FM64, prod_bw,
+                           /*signed_arith=*/false);
+
+  // Product lives in 2q+2-bit ring.
+  ring_reduce_(m_prod.data(), prod_bw);
+  m_prod.data().set_fxp_bits(static_cast<int64_t>(prod_bw));
+
+  // 3. c = GT(2^{2q+1} - 2^{q-1}, m)
+  //
+  // c = 1 means product is in the lower normalized range:
+  // choose RNTE(m, q), exponent unchanged.
+  const uint128_t threshold =
+      (uint128_t{1} << (2 * q + 1)) - (uint128_t{1} << (q - 1));
+
+  auto c = LessThanPublicByMsb(ctx, m_prod, threshold, prod_bw);
+
+  // 4. m1 = RNTE(m, q) mod 2^{q+1}
+  auto m1 = RNTE(ctx, m_prod, static_cast<size_t>(q), mantissa_bw);
+
+  // 5. m2 = RNTE(m, q + 1)
+  auto m2 = RNTE(ctx, m_prod, static_cast<size_t>(q + 1), mantissa_bw);
+
+  // 6. e2 = e + 1
+  const auto e_field = e.storage_type().as<Ring2k>()->field();
+  auto one_e = make_p(ctx, uint128_t{1}, e.shape(), e_field);
+  auto e2 = add_sp(ctx, e, one_e);
+
+  // 7. m = MUX(c, m1, m2)
+  auto m = MuxA(ctx, c, m1, m2);
+
+  // Final mantissa must be canonical q+1-bit value.
+  ring_reduce_(m.data(), mantissa_bw);
+  m.data().set_fxp_bits(static_cast<int64_t>(mantissa_bw));
+
+  // 8. e = MUX(c, e, e2)
+  auto e_final = MuxA(ctx, c, e, e2);
+
+  // 9. s = lhs.s XOR rhs.s
+  auto s = BitXorA(ctx, lhs.s, rhs.s);
+
+  // 10. z = lhs.z OR rhs.z
+  auto z = BitOrA(ctx, lhs.z, rhs.z);
+
+  // 11. FPCheck(z, s, e, m)
+  auto out = FPCheck(ctx, SharedFloat(z, s, e_final, m, p, q));
+
+  // FPCheck may preserve arithmetic high bits in m, so canonicalize again.
+  ring_reduce_(out.m.data(), mantissa_bw);
+  out.m.data().set_fxp_bits(static_cast<int64_t>(mantissa_bw));
+
+  return out;
+}
+
+}  // namespace spu::mpc::flp

--- a/src/libspu/mpc/flp/fp_mul.h
+++ b/src/libspu/mpc/flp/fp_mul.h
@@ -1,0 +1,29 @@
+#ifndef SPU_MPC_FLP_FP_MUL_H_
+#define SPU_MPC_FLP_FP_MUL_H_
+
+#include "libspu/core/context.h"
+#include "libspu/mpc/flp/float_type.h"
+
+namespace spu::mpc::flp {
+
+// Floating-point multiplication over SharedFloat.
+//
+// Current representation convention:
+//   - z: secret arithmetic Value, 0/1 zero flag
+//   - s: secret arithmetic Value, 0/1 sign bit
+//   - e: secret arithmetic Value, unbiased exponent
+//   - m: secret arithmetic Value, explicit mantissa with q + 1 bits
+//
+// The implementation is expected to:
+//   1. compute z = lhs.z OR rhs.z over arithmetic 0/1 shares;
+//   2. compute s = lhs.s XOR rhs.s over arithmetic 0/1 shares;
+//   3. compute e = lhs.e + rhs.e;
+//   4. compute mantissa product with mixed-width multiplication;
+//   5. call RoundMantissaAndCheckSharedApi;
+//   6. call FPCheck.
+SharedFloat FPMul(SPUContext* ctx, const SharedFloat& lhs,
+                  const SharedFloat& rhs);
+
+}  // namespace spu::mpc::flp
+
+#endif  // SPU_MPC_FLP_FP_MUL_H_

--- a/src/libspu/mpc/flp/fp_mul_perf_test.cc
+++ b/src/libspu/mpc/flp/fp_mul_perf_test.cc
@@ -1,0 +1,116 @@
+#include <cstdint>
+#include <iostream>
+#include <memory>
+
+#include "gtest/gtest.h"
+#include "yacl/utils/elapsed_timer.h"
+
+#include "libspu/mpc/api.h"
+#include "libspu/mpc/cheetah/protocol.h"
+#include "libspu/mpc/common/communicator.h"
+#include "libspu/mpc/flp/fp_mul.h"
+#include "libspu/mpc/utils/simulate.h"
+
+namespace spu::mpc::flp {
+namespace {
+
+const int kP = 8;
+const int kQ = 23;
+const int kIterations = 2000;
+const int64_t kBatchSize = 128;
+
+std::unique_ptr<SPUContext> MakeCheetahCtx(
+    const std::shared_ptr<yacl::link::Context>& lctx) {
+  RuntimeConfig conf;
+  conf.protocol = ProtocolKind::CHEETAH;
+  conf.field = FM64;
+  return makeCheetahProtocol(conf, lctx);
+}
+
+Value MakePublic(SPUContext* ctx, int64_t val, const Shape& shape,
+                 int64_t fxp_bits = 0) {
+  auto v = make_p(ctx, static_cast<uint128_t>(static_cast<uint64_t>(val)),
+                  shape, FM64);
+  if (fxp_bits > 0) {
+    v.data().set_fxp_bits(fxp_bits);
+  }
+  return v;
+}
+
+Value MakeSecret(SPUContext* ctx, int64_t val, const Shape& shape,
+                 int64_t fxp_bits = 0) {
+  return p2s(ctx, MakePublic(ctx, val, shape, fxp_bits));
+}
+
+SharedFloat MakeSharedFloat(SPUContext* ctx, int64_t z, int64_t s, int64_t e,
+                            int64_t m, const Shape& shape) {
+  auto z_s = MakeSecret(ctx, z, shape);
+  auto s_s = MakeSecret(ctx, s, shape);
+  auto e_s = MakeSecret(ctx, e, shape);
+
+  // Mantissa uses q + 1 bits because it explicitly stores the leading 1.
+  auto m_s = MakeSecret(ctx, m, shape, kQ + 1);
+
+  return SharedFloat(z_s, s_s, e_s, m_s, kP, kQ);
+}
+
+}  // namespace
+
+TEST(FPMulPerfTest, Run2000) {
+  const int npc = 2;
+  const Shape shape = {kBatchSize};
+
+  const int64_t one_m = 1LL << kQ;
+
+  // 1.5 and 1.25 in current SharedFloat format:
+  // value = m * 2^(e - q)
+  const int64_t m_a = one_m + (one_m >> 1);  // 1.5
+  const int64_t m_b = one_m + (one_m >> 2);  // 1.25
+
+  utils::simulate(npc, [&](const std::shared_ptr<yacl::link::Context>& lctx) {
+    auto ctx = MakeCheetahCtx(lctx);
+    const int rank = lctx->Rank();
+
+    auto lhs = MakeSharedFloat(ctx.get(), 0, 0, 0, m_a, shape);
+    auto rhs = MakeSharedFloat(ctx.get(), 0, 0, 0, m_b, shape);
+
+    // Warm-up: initialize OT connections and avoid counting first-call
+    // overhead.
+    FPMul(ctx.get(), lhs, rhs);
+
+    size_t b0 = lctx->GetStats()->sent_bytes;
+    size_t r0 = lctx->GetStats()->sent_actions;
+
+    yacl::ElapsedTimer timer;
+    for (int i = 0; i < kIterations; ++i) {
+      FPMul(ctx.get(), lhs, rhs);
+    }
+    double elapsed_ms = timer.CountMs();
+
+    size_t b1 = lctx->GetStats()->sent_bytes;
+    size_t r1 = lctx->GetStats()->sent_actions;
+
+    if (rank == 0) {
+      std::cout << "--- FPMul perf over " << kIterations << " iterations ---"
+                << std::endl;
+      std::cout << "  batch size:     " << kBatchSize << std::endl;
+      std::cout << "  total time:     " << elapsed_ms << " ms" << std::endl;
+      std::cout << "  avg time:       " << (elapsed_ms / kIterations)
+                << " ms/call" << std::endl;
+      std::cout << "  avg time/elem:  "
+                << (elapsed_ms / kIterations / kBatchSize) << " ms/elem"
+                << std::endl;
+      std::cout << "  total sent:     " << ((b1 - b0) / 1024.0) << " KiB"
+                << std::endl;
+      std::cout << "  avg sent:       " << ((b1 - b0) * 1.0 / kIterations)
+                << " bytes/call" << std::endl;
+      std::cout << "  avg sent/elem:  "
+                << ((b1 - b0) * 1.0 / kIterations / kBatchSize) << " bytes/elem"
+                << std::endl;
+      std::cout << "  avg actions:    " << ((r1 - r0) * 1.0 / kIterations)
+                << " per call" << std::endl;
+    }
+  });
+}
+
+}  // namespace spu::mpc::flp

--- a/src/libspu/mpc/flp/fp_mul_test.cc
+++ b/src/libspu/mpc/flp/fp_mul_test.cc
@@ -1,0 +1,280 @@
+#include "libspu/mpc/flp/fp_mul.h"
+
+#include <random>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "libspu/mpc/api.h"
+#include "libspu/mpc/cheetah/protocol.h"
+#include "libspu/mpc/utils/ring_ops.h"
+#include "libspu/mpc/utils/simulate.h"
+
+namespace spu::mpc::flp {
+namespace {
+
+const int kP = 8;
+const int kQ = 23;
+
+std::unique_ptr<SPUContext> MakeCheetahCtx(
+    const std::shared_ptr<yacl::link::Context>& lctx) {
+  RuntimeConfig conf;
+  conf.protocol = ProtocolKind::CHEETAH;
+  conf.field = FM64;
+  return makeCheetahProtocol(conf, lctx);
+}
+
+Value MakePublic(SPUContext* ctx, int64_t val, const Shape& shape,
+                 int64_t fxp_bits = 0) {
+  auto v = make_p(ctx, static_cast<uint128_t>(static_cast<uint64_t>(val)),
+                  shape, FM64);
+  if (fxp_bits > 0) {
+    v.data().set_fxp_bits(fxp_bits);
+  }
+  return v;
+}
+
+Value MakeSecret(SPUContext* ctx, int64_t val, const Shape& shape,
+                 int64_t fxp_bits = 0) {
+  return p2s(ctx, MakePublic(ctx, val, shape, fxp_bits));
+}
+
+SharedFloat MakeSharedFloat(SPUContext* ctx, int64_t z, int64_t s, int64_t e,
+                            int64_t m, const Shape& shape) {
+  auto z_s = MakeSecret(ctx, z, shape);
+  auto s_s = MakeSecret(ctx, s, shape);
+  auto e_s = MakeSecret(ctx, e, shape);
+
+  // Mantissa is q + 1 bits.
+  auto m_s = MakeSecret(ctx, m, shape, kQ + 1);
+
+  return SharedFloat(z_s, s_s, e_s, m_s, kP, kQ);
+}
+
+void CheckValue(const Value& got, const Value& expected) {
+  EXPECT_EQ(got.shape(), expected.shape());
+  EXPECT_TRUE(ring_all_equal(got.data(), expected.data()));
+}
+
+void CheckSharedFloat(SPUContext* ctx, const SharedFloat& got, int64_t z,
+                      int64_t s, int64_t e, int64_t m, const Shape& shape) {
+  CheckValue(s2p(ctx, got.z), MakePublic(ctx, z, shape));
+  CheckValue(s2p(ctx, got.s), MakePublic(ctx, s, shape));
+  CheckValue(s2p(ctx, got.e), MakePublic(ctx, e, shape));
+  CheckValue(s2p(ctx, got.m), MakePublic(ctx, m, shape));
+}
+
+}  // namespace
+
+struct PlainFloat {
+  int64_t z;
+  int64_t s;
+  int64_t e;
+  int64_t m;
+};
+
+uint64_t MaskBits(size_t bits) {
+  if (bits == 64) {
+    return static_cast<uint64_t>(-1);
+  }
+  return (uint64_t{1} << bits) - 1;
+}
+
+uint64_t RNTEPlain(uint128_t x, size_t shift_bits, size_t out_bits) {
+  uint128_t rounded = (x + (uint128_t{1} << (shift_bits - 1))) >> shift_bits;
+  return static_cast<uint64_t>(rounded) & MaskBits(out_bits);
+}
+
+PlainFloat FPMulPlainRef(const PlainFloat& lhs, const PlainFloat& rhs) {
+  const int q = kQ;
+
+  PlainFloat out;
+  out.z = lhs.z | rhs.z;
+  out.s = lhs.s ^ rhs.s;
+
+  int64_t e = lhs.e + rhs.e;
+  uint128_t m_prod =
+      static_cast<uint128_t>(lhs.m) * static_cast<uint128_t>(rhs.m);
+
+  // Match current fp_mul.cc:
+  // c = 1{m_prod < 2^{2q+1} - 2^{q-1}}
+  const uint128_t threshold =
+      (uint128_t{1} << (2 * q + 1)) - (uint128_t{1} << (q - 1));
+
+  uint64_t m;
+  if (m_prod < threshold) {
+    // choose RNTE(m, q), exponent unchanged
+    m = RNTEPlain(m_prod, static_cast<size_t>(q), static_cast<size_t>(q + 1));
+  } else {
+    // choose RNTE(m, q + 1), exponent + 1
+    m = RNTEPlain(m_prod, static_cast<size_t>(q + 1),
+                  static_cast<size_t>(q + 1));
+    e += 1;
+  }
+
+  out.e = e;
+  out.m = static_cast<int64_t>(m);
+
+  // Match FPCheck.
+  const int64_t overflow_thresh = (1LL << (kP - 1)) - 1;
+  const int64_t max_e = 1LL << (kP - 1);
+  const int64_t min_e = 1 - (1LL << (kP - 1));
+  const uint64_t max_m = 1ULL << kQ;
+
+  const bool cond_ov = out.e > overflow_thresh;
+  const bool cond_un = (out.z == 1) || (out.e < (2 - (1LL << (kP - 1))));
+
+  if (cond_ov) {
+    out.e = max_e;
+    out.m = static_cast<int64_t>(max_m);
+  }
+
+  if (cond_un) {
+    out.z = 1;
+    out.e = min_e;
+    out.m = 0;
+  }
+
+  return out;
+}
+
+TEST(FPMulTest, OneTimesOne) {
+  const int npc = 2;
+  const Shape shape = {1};
+  const int64_t one_m = 1LL << kQ;
+
+  utils::simulate(npc, [&](const std::shared_ptr<yacl::link::Context>& lctx) {
+    auto ctx = MakeCheetahCtx(lctx);
+
+    auto lhs = MakeSharedFloat(ctx.get(), /*z=*/0, /*s=*/0, /*e=*/0,
+                               /*m=*/one_m, shape);
+    auto rhs = MakeSharedFloat(ctx.get(), /*z=*/0, /*s=*/0, /*e=*/0,
+                               /*m=*/one_m, shape);
+
+    auto out = FPMul(ctx.get(), lhs, rhs);
+
+    CheckSharedFloat(ctx.get(), out, /*z=*/0, /*s=*/0, /*e=*/0,
+                     /*m=*/one_m, shape);
+  });
+}
+
+TEST(FPMulTest, ExponentAdd) {
+  const int npc = 2;
+  const Shape shape = {1};
+  const int64_t one_m = 1LL << kQ;
+
+  utils::simulate(npc, [&](const std::shared_ptr<yacl::link::Context>& lctx) {
+    auto ctx = MakeCheetahCtx(lctx);
+
+    auto lhs = MakeSharedFloat(ctx.get(), /*z=*/0, /*s=*/0, /*e=*/2,
+                               /*m=*/one_m, shape);
+    auto rhs = MakeSharedFloat(ctx.get(), /*z=*/0, /*s=*/0, /*e=*/3,
+                               /*m=*/one_m, shape);
+
+    auto out = FPMul(ctx.get(), lhs, rhs);
+
+    CheckSharedFloat(ctx.get(), out, /*z=*/0, /*s=*/0, /*e=*/5,
+                     /*m=*/one_m, shape);
+  });
+}
+
+TEST(FPMulTest, SignXor) {
+  const int npc = 2;
+  const Shape shape = {1};
+  const int64_t one_m = 1LL << kQ;
+
+  utils::simulate(npc, [&](const std::shared_ptr<yacl::link::Context>& lctx) {
+    auto ctx = MakeCheetahCtx(lctx);
+
+    auto lhs = MakeSharedFloat(ctx.get(), /*z=*/0, /*s=*/0, /*e=*/0,
+                               /*m=*/one_m, shape);
+    auto rhs = MakeSharedFloat(ctx.get(), /*z=*/0, /*s=*/1, /*e=*/0,
+                               /*m=*/one_m, shape);
+
+    auto out = FPMul(ctx.get(), lhs, rhs);
+
+    CheckSharedFloat(ctx.get(), out, /*z=*/0, /*s=*/1, /*e=*/0,
+                     /*m=*/one_m, shape);
+  });
+}
+
+TEST(FPMulTest, ZeroFlag) {
+  const int npc = 2;
+  const Shape shape = {1};
+  const int64_t one_m = 1LL << kQ;
+  const int64_t min_e = 1 - (1LL << (kP - 1));
+
+  utils::simulate(npc, [&](const std::shared_ptr<yacl::link::Context>& lctx) {
+    auto ctx = MakeCheetahCtx(lctx);
+
+    auto lhs = MakeSharedFloat(ctx.get(), /*z=*/1, /*s=*/0, /*e=*/0,
+                               /*m=*/one_m, shape);
+    auto rhs = MakeSharedFloat(ctx.get(), /*z=*/0, /*s=*/0, /*e=*/0,
+                               /*m=*/one_m, shape);
+
+    auto out = FPMul(ctx.get(), lhs, rhs);
+
+    // FPCheck should clamp zero result to z=1, e=min_e, m=0.
+    CheckSharedFloat(ctx.get(), out, /*z=*/1, /*s=*/0, /*e=*/min_e,
+                     /*m=*/0, shape);
+  });
+}
+
+TEST(FPMulTest, RandomNormalValues) {
+  const int npc = 2;
+  const Shape shape = {1};
+
+  constexpr int kNumCases = 160;
+  std::mt19937_64 rng(202605529);
+
+  std::uniform_int_distribution<int64_t> sign_dist(0, 1);
+  std::uniform_int_distribution<int64_t> exp_dist(-10, 10);
+  std::uniform_int_distribution<int64_t> mantissa_dist(1LL << kQ,
+                                                       (1LL << (kQ + 1)) - 1);
+
+  std::vector<PlainFloat> lhs_cases;
+  std::vector<PlainFloat> rhs_cases;
+
+  lhs_cases.reserve(kNumCases);
+  rhs_cases.reserve(kNumCases);
+
+  for (int i = 0; i < kNumCases; ++i) {
+    lhs_cases.push_back(PlainFloat{
+        /*z=*/0,
+        /*s=*/sign_dist(rng),
+        /*e=*/exp_dist(rng),
+        /*m=*/mantissa_dist(rng),
+    });
+
+    rhs_cases.push_back(PlainFloat{
+        /*z=*/0,
+        /*s=*/sign_dist(rng),
+        /*e=*/exp_dist(rng),
+        /*m=*/mantissa_dist(rng),
+    });
+  }
+
+  utils::simulate(npc, [&](const std::shared_ptr<yacl::link::Context>& lctx) {
+    auto ctx = MakeCheetahCtx(lctx);
+
+    for (int i = 0; i < kNumCases; ++i) {
+      const auto& lhs_plain = lhs_cases[i];
+      const auto& rhs_plain = rhs_cases[i];
+      auto expected = FPMulPlainRef(lhs_plain, rhs_plain);
+
+      auto lhs = MakeSharedFloat(ctx.get(), lhs_plain.z, lhs_plain.s,
+                                 lhs_plain.e, lhs_plain.m, shape);
+      auto rhs = MakeSharedFloat(ctx.get(), rhs_plain.z, rhs_plain.s,
+                                 rhs_plain.e, rhs_plain.m, shape);
+
+      auto out = FPMul(ctx.get(), lhs, rhs);
+
+      CheckSharedFloat(ctx.get(), out, expected.z, expected.s, expected.e,
+                       expected.m, shape);
+    }
+  });
+}
+
+}  // namespace spu::mpc::flp
+
+// namespace spu::mpc::flp

--- a/src/libspu/mpc/flp/fp_mul_ulp_test.cc
+++ b/src/libspu/mpc/flp/fp_mul_ulp_test.cc
@@ -1,0 +1,258 @@
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <random>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "libspu/mpc/api.h"
+#include "libspu/mpc/cheetah/protocol.h"
+#include "libspu/mpc/flp/fp_mul.h"
+#include "libspu/mpc/utils/ring_ops.h"
+#include "libspu/mpc/utils/simulate.h"
+
+namespace spu::mpc::flp {
+namespace {
+
+const int kP = 8;
+const int kQ = 23;
+const int kNumSamples = 1000;
+
+std::unique_ptr<SPUContext> MakeCheetahCtx(
+    const std::shared_ptr<yacl::link::Context>& lctx) {
+  RuntimeConfig conf;
+  conf.protocol = ProtocolKind::CHEETAH;
+  conf.field = FM64;
+  return makeCheetahProtocol(conf, lctx);
+}
+
+Value MakePublic(SPUContext* ctx, int64_t val, const Shape& shape,
+                 int64_t fxp_bits = 0) {
+  auto v = make_p(ctx, static_cast<uint128_t>(static_cast<uint64_t>(val)),
+                  shape, FM64);
+  if (fxp_bits > 0) {
+    v.data().set_fxp_bits(fxp_bits);
+  }
+  return v;
+}
+
+Value MakeSecret(SPUContext* ctx, int64_t val, const Shape& shape,
+                 int64_t fxp_bits = 0) {
+  return p2s(ctx, MakePublic(ctx, val, shape, fxp_bits));
+}
+
+SharedFloat MakeSharedFloat(SPUContext* ctx, int64_t z, int64_t s, int64_t e,
+                            int64_t m, const Shape& shape) {
+  auto z_s = MakeSecret(ctx, z, shape);
+  auto s_s = MakeSecret(ctx, s, shape);
+  auto e_s = MakeSecret(ctx, e, shape);
+
+  // Mantissa uses q + 1 bits because it explicitly stores the leading 1.
+  auto m_s = MakeSecret(ctx, m, shape, kQ + 1);
+
+  return SharedFloat(z_s, s_s, e_s, m_s, kP, kQ);
+}
+
+double FloatToDouble(int64_t z, int64_t s, int64_t e, int64_t m) {
+  if (z != 0) {
+    return 0.0;
+  }
+
+  const double sign = (s != 0) ? -1.0 : 1.0;
+  return sign * static_cast<double>(m) *
+         std::ldexp(1.0, static_cast<int>(e - kQ));
+}
+
+// ULP spacing around exact_val for the current q-bit fraction format.
+// Current format has q + 1 effective mantissa bits.
+double ULP(double exact_val) {
+  int exp = 0;
+  std::frexp(std::abs(exact_val), &exp);
+  return std::ldexp(1.0, exp - 1 - kQ);
+}
+
+struct ULPStats {
+  int count_zero = 0;   // ULP == 0
+  int count_half = 0;   // 0 < ULP <= 0.5
+  int count_one = 0;    // 0.5 < ULP <= 1
+  int count_above = 0;  // ULP > 1
+
+  double max_ulp = 0.0;
+  double sum_ulp = 0.0;
+  int total = 0;
+};
+
+// Plain tuple: (z, s, e, m)
+using PlainTuple = std::tuple<int64_t, int64_t, int64_t, int64_t>;
+
+struct TestCase {
+  PlainTuple a;
+  PlainTuple b;
+};
+
+std::vector<TestCase> GenerateSamples() {
+  std::mt19937_64 rng(20250603);
+
+  const int64_t one_m = 1LL << kQ;
+  const int64_t max_m = (1LL << (kQ + 1)) - 1;
+
+  std::uniform_int_distribution<int64_t> s_dist(0, 1);
+  std::uniform_int_distribution<int64_t> e_dist(-10, 10);
+
+  const int samples_per_layer = kNumSamples / 4;
+
+  std::vector<TestCase> cases;
+  cases.reserve(kNumSamples);
+
+  // Layer 1:
+  // Low mantissa product.
+  // Usually chooses RNTE(m_prod, q), exponent unchanged.
+  {
+    std::uniform_int_distribution<int64_t> m_dist(one_m, one_m + (one_m >> 2));
+
+    for (int i = 0; i < samples_per_layer; ++i) {
+      cases.push_back({
+          {0, s_dist(rng), e_dist(rng), m_dist(rng)},
+          {0, s_dist(rng), e_dist(rng), m_dist(rng)},
+      });
+    }
+  }
+
+  // Layer 2:
+  // High mantissa product.
+  // Usually chooses RNTE(m_prod, q + 1), exponent + 1.
+  {
+    std::uniform_int_distribution<int64_t> m_dist(one_m + (one_m >> 1), max_m);
+
+    for (int i = 0; i < samples_per_layer; ++i) {
+      cases.push_back({
+          {0, s_dist(rng), e_dist(rng), m_dist(rng)},
+          {0, s_dist(rng), e_dist(rng), m_dist(rng)},
+      });
+    }
+  }
+
+  // Layer 3:
+  // Fully random normal mantissas.
+  {
+    std::uniform_int_distribution<int64_t> m_dist(one_m, max_m);
+
+    for (int i = 0; i < samples_per_layer; ++i) {
+      cases.push_back({
+          {0, s_dist(rng), e_dist(rng), m_dist(rng)},
+          {0, s_dist(rng), e_dist(rng), m_dist(rng)},
+      });
+    }
+  }
+
+  // Layer 4:
+  // Identity cases: x * 1.0.
+  {
+    std::uniform_int_distribution<int64_t> m_dist(one_m, max_m);
+
+    for (int i = 0; i < samples_per_layer; ++i) {
+      cases.push_back({
+          {0, s_dist(rng), e_dist(rng), m_dist(rng)},
+          {0, 0, 0, one_m},
+      });
+    }
+  }
+
+  return cases;
+}
+
+TEST(FPMulULPTest, RandomNormalSamples) {
+  const int npc = 2;
+  const Shape shape = {1};
+
+  const auto cases = GenerateSamples();
+
+  std::vector<ULPStats> per_party(npc);
+
+  utils::simulate(npc, [&](const std::shared_ptr<yacl::link::Context>& lctx) {
+    auto ctx = MakeCheetahCtx(lctx);
+    const int rank = lctx->Rank();
+
+    for (const auto& c : cases) {
+      auto [az, as, ae, am] = c.a;
+      auto [bz, bs, be, bm] = c.b;
+
+      auto lhs = MakeSharedFloat(ctx.get(), az, as, ae, am, shape);
+      auto rhs = MakeSharedFloat(ctx.get(), bz, bs, be, bm, shape);
+
+      auto out = FPMul(ctx.get(), lhs, rhs);
+
+      auto rz = s2p(ctx.get(), out.z);
+      auto rs = s2p(ctx.get(), out.s);
+      auto re = s2p(ctx.get(), out.e);
+      auto rm = s2p(ctx.get(), out.m);
+
+      const auto got_z =
+          static_cast<int64_t>(NdArrayView<const uint64_t>(rz.data())[0]);
+      const auto got_s =
+          static_cast<int64_t>(NdArrayView<const uint64_t>(rs.data())[0]);
+      const auto got_e =
+          static_cast<int64_t>(NdArrayView<const uint64_t>(re.data())[0]);
+      const auto got_m =
+          static_cast<int64_t>(NdArrayView<const uint64_t>(rm.data())[0]);
+
+      const double v_a = FloatToDouble(az, as, ae, am);
+      const double v_b = FloatToDouble(bz, bs, be, bm);
+
+      // For multiplication, double is enough here:
+      // 24-bit mantissa * 24-bit mantissa produces at most 48 exact bits,
+      // while double has 53 mantissa bits.
+      const double v_exact = v_a * v_b;
+
+      if (v_exact == 0.0) {
+        per_party[rank].count_zero++;
+        per_party[rank].total++;
+        continue;
+      }
+
+      const double v_got = FloatToDouble(got_z, got_s, got_e, got_m);
+      const double ulp_val = ULP(v_exact);
+      const double ulp_err = std::abs(v_got - v_exact) / ulp_val;
+
+      per_party[rank].sum_ulp += ulp_err;
+      per_party[rank].max_ulp = std::max(per_party[rank].max_ulp, ulp_err);
+      per_party[rank].total++;
+
+      if (ulp_err == 0.0) {
+        per_party[rank].count_zero++;
+      } else if (ulp_err <= 0.5) {
+        per_party[rank].count_half++;
+      } else if (ulp_err <= 1.0) {
+        per_party[rank].count_one++;
+      } else {
+        per_party[rank].count_above++;
+      }
+    }
+  });
+
+  const auto& stats = per_party[0];
+
+  std::cout << "--- FPMul ULP Error Test (" << stats.total << " samples) ---"
+            << std::endl;
+  std::cout << "  ULP = 0:         " << stats.count_zero << " ("
+            << (100.0 * stats.count_zero / stats.total) << "%)" << std::endl;
+  std::cout << "  ULP in (0, 0.5]: " << stats.count_half << " ("
+            << (100.0 * stats.count_half / stats.total) << "%)" << std::endl;
+  std::cout << "  ULP in (0.5, 1]: " << stats.count_one << " ("
+            << (100.0 * stats.count_one / stats.total) << "%)" << std::endl;
+  std::cout << "  ULP > 1:         " << stats.count_above << " ("
+            << (100.0 * stats.count_above / stats.total) << "%)" << std::endl;
+  std::cout << "  Max ULP:         " << stats.max_ulp << std::endl;
+  std::cout << "  Mean ULP:        " << (stats.sum_ulp / stats.total)
+            << std::endl;
+
+  EXPECT_EQ(stats.count_above, 0)
+      << stats.count_above << " samples exceed 1 ULP";
+}
+
+}  // namespace
+}  // namespace spu::mpc::flp

--- a/src/libspu/mpc/flp/round_and_check_fp_api.cc
+++ b/src/libspu/mpc/flp/round_and_check_fp_api.cc
@@ -1,0 +1,95 @@
+#include "libspu/mpc/flp/round_and_check_fp_api.h"
+
+#include <cstdint>
+
+#include "libspu/mpc/ab_api.h"
+
+namespace spu::mpc::flp {
+
+// Implements ΠRound&Check from BEACON (Figure 9).
+//   Input:  mantissa m with (Q+1) bits, exponent e with (p+2) bits
+//   Output: mantissa m' with (q+1) bits, exponent e' with (p+2) bits
+//
+//   Step 1: ⟨c⟩ = ΠLT(⟨m⟩_{Q+1}, 2^{Q+1} − 2^{Q−q−1})
+//   Step 2: ⟨mc⟩_{q+1} = ΠRN^{Q+1,Q−q}(⟨m⟩_{Q+1})
+//   Step 3: ⟨m'⟩_{q+1} = ΠMUX(⟨c⟩_B, ⟨mc⟩_{q+1}, 2^q)
+//   Step 4: ⟨e'⟩_{p+2} = ΠMUX(⟨c⟩_B, ⟨e⟩_{p+2}, ⟨e⟩_{p+2} + 1)
+//
+//   ΠMUX semantics: ΠMUX(c, x, y) = c ? x : y  (c=1 selects x)
+//   ΠRN(x, s) = (x + 2^{s-1}) >> s  (round-to-nearest, ties-up)
+//
+SharedFloat RoundMantissaAndCheckSharedApi(SPUContext* ctx,
+                                           const SharedFloat& in, int Q,
+                                           int q) {
+  const int s = Q - q;
+  const FieldType field = in.m.storage_type().as<Ring2k>()->field();
+
+  const uint128_t round_bias = uint128_t{1} << (s - 1);
+  const uint128_t threshold = (uint128_t{1} << (Q + 1)) -
+                               (uint128_t{1} << (Q - q - 1));
+
+  auto bias_p = make_p(ctx, round_bias, in.m.shape(), field);
+  auto threshold_p = make_p(ctx, threshold, in.m.shape(), field);
+
+  // Step 2: ΠRN — round-to-nearest (ties-up)
+  //   m_c = (m + 2^{s-1}) >> s
+  auto m_plus = add_ss(ctx, in.m, p2s(ctx, bias_p));
+  auto m_c = trunc2_s(ctx, m_plus, static_cast<size_t>(s),
+                      SignType::Unknown, true, true);
+
+  // Renormalized mantissa for overflow case: m_c >> 1 = 2^q (fits in q+1 bits)
+  auto m_renorm = trunc2_s(ctx, m_c, 1, SignType::Unknown, true, true);
+
+  // Step 1: ΠLT — compare m against threshold
+  //   cmp = m - threshold in ring arithmetic
+  //   MSB=1 when m < threshold (unsigned wrap-around = negative in 2's complement)
+  //   MSB=0 when m >= threshold
+  auto cmp_x = add_ss(ctx, in.m, negate_s(ctx, p2s(ctx, threshold_p)));
+  auto msb_bit_full = msb_s(ctx, cmp_x);
+  // Extract LSB (all bits are identical since msb_s returns all-bits=MSB)
+  auto c_bshare = and_bp(ctx, msb_bit_full,
+                         make_p(ctx, 1, in.m.shape(), field));
+
+  // need_overflow = NOT(c) = 1 when m >= threshold (overflow case)
+  // Paper: c=1 → no overflow (m < threshold), c=0 → overflow (m >= threshold)
+  //        need_overflow = 1-c = NOT(c)
+  auto need_overflow = xor_bp(ctx, c_bshare,
+                              make_p(ctx, 1, in.m.shape(), field));
+
+  // Step 3: ΠMUX — select mantissa
+  //   c=1 (no overflow):  m' = m_c  (RN result)
+  //   c=0 (overflow):     m' = 2^q  (renormalized)
+  //
+  //   In terms of need_overflow:
+  //     need_overflow=0 (no overflow): m' = m_c
+  //     need_overflow=1 (overflow):    m' = m_renorm (= m_c >> 1 = 2^q)
+  //
+  //   Using arithmetic: m' = m_c - (m_c - m_renorm) * need_overflow
+  auto diff = add_ss(ctx, m_c, negate_s(ctx, m_renorm));
+  auto m_prime = add_ss(ctx, m_c,
+                        negate_s(ctx, mul_a1b(ctx, diff, need_overflow)));
+
+  // Step 4: ΠMUX — select exponent
+  //   c=1 (no overflow): e' = e
+  //   c=0 (overflow):    e' = e + 1
+  //
+  //   In terms of need_overflow:
+  //     need_overflow=0 (no overflow): e' = e
+  //     need_overflow=1 (overflow):    e' = e + 1
+  auto e_prime = add_ss(ctx, in.e,
+                        mul_a1b(ctx,
+                                p2s(ctx, make_p(ctx, 1, in.e.shape(), field)),
+                                need_overflow));
+
+  SharedFloat out;
+  out.z = in.z;
+  out.s = in.s;
+  out.e = e_prime;
+  out.m = m_prime;
+  out.p = in.p;
+  out.q = q;
+
+  return out;
+}
+
+}  // namespace spu::mpc::flp

--- a/src/libspu/mpc/flp/round_and_check_fp_api.h
+++ b/src/libspu/mpc/flp/round_and_check_fp_api.h
@@ -1,0 +1,19 @@
+#ifndef SPU_MPC_FLP_ROUND_AND_CHECK_FP_API_H_
+#define SPU_MPC_FLP_ROUND_AND_CHECK_FP_API_H_
+
+#include <cstdint>
+
+#include <memory>
+
+#include "libspu/mpc/flp/float_type.h"
+#include "libspu/mpc/api.h"
+
+namespace spu::mpc::flp {
+
+SharedFloat RoundMantissaAndCheckSharedApi(SPUContext* ctx,
+                                           const SharedFloat& in, int Q,
+                                           int q);
+
+}  // namespace spu::mpc::flp
+
+#endif  // SPU_MPC_FLP_ROUND_AND_CHECK_FP_API_H_

--- a/src/libspu/mpc/flp/round_and_check_fp_api_test.cc
+++ b/src/libspu/mpc/flp/round_and_check_fp_api_test.cc
@@ -1,0 +1,303 @@
+// Functional test for RoundMantissaAndCheckSharedApi using two-party simulate.
+// Implements ΠRound&Check from BEACON [Rathee et al., S&P 2024, Figure 9].
+// Uses (p, Q, q) = (8, 15, 7) matching the BF16 setting from the paper.
+// Verification: reconstructed mantissa and exponent must match plaintext reference.
+
+#include "libspu/mpc/flp/round_and_check_fp_api.h"
+
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <random>
+
+#include "gtest/gtest.h"
+#include "libspu/core/ndarray_ref.h"
+#include "libspu/core/type_util.h"
+#include "libspu/mpc/api.h"
+#include "libspu/mpc/cheetah/io.h"
+#include "libspu/mpc/cheetah/protocol.h"
+#include "libspu/mpc/common/communicator.h"
+#include "libspu/mpc/utils/ring_ops.h"
+#include "libspu/mpc/utils/simulate.h"
+
+namespace spu::mpc::flp {
+namespace {
+
+RuntimeConfig MakeConfig() {
+  RuntimeConfig conf;
+  conf.protocol = ProtocolKind::CHEETAH;
+  conf.field = FieldType::FM64;
+  conf.cheetah_2pc_config.ot_kind = CheetahOtKind::YACL_Softspoken;
+  return conf;
+}
+
+// Reference threshold: 2^{Q+1} - 2^{Q-q-1}
+uint64_t RefThreshold(int Q, int q) {
+  return (uint64_t{1} << (Q + 1)) - (uint64_t{1} << (Q - q - 1));
+}
+
+// Paper's ΠRN: (x + 2^{s-1}) >> s   (round-to-nearest, ties-up)
+uint64_t RefRN(uint64_t x, int s) {
+  return (x + (uint64_t{1} << (s - 1))) >> s;
+}
+
+// Paper's ΠRound&Check reference (plaintext).
+//   Input:  mantissa m (Q+1 bits), exponent e
+//   Output: mantissa out_m (q+1 bits), exponent out_e
+//
+//   c = (m < 2^{Q+1} - 2^{Q-q-1})   // 1=no overflow, 0=overflow
+//   m_c = RN(m) = (m + 2^{s-1}) >> s
+//   out_m = c ? m_c : (m_c >> 1)     // m_c >> 1 = 2^q when overflow
+//   out_e = c ? e   : e + 1
+void RefRoundAndCheck(int Q, int q, uint64_t m, uint64_t e,
+                      uint64_t& out_m, uint64_t& out_e) {
+  const int s = Q - q;
+  const uint64_t threshold = RefThreshold(Q, q);
+  const uint64_t m_c = RefRN(m, s);       // RN result
+  const uint64_t m_renorm = m_c >> 1;     // = 2^q when overflow
+
+  // c = (m < threshold) → 1=no overflow, 0=overflow
+  if (m < threshold) {
+    out_m = m_c;       // use RN result
+    out_e = e;         // exponent unchanged
+  } else {
+    out_m = m_renorm;  // renormalized to 2^q
+    out_e = e + 1;     // exponent incremented
+  }
+}
+
+}  // namespace
+
+TEST(RoundAndCheckFpApiTest, MatchesPaperProtocol) {
+  // BF16 settings from BEACON paper: p=8 exponent bits, q=7 mantissa bits.
+  // Q=15 gives higher intermediate precision (16-bit mantissa).
+  constexpr int kQ = 15;
+  constexpr int kq = 7;
+  constexpr size_t kWorldSize = 2;
+  constexpr FieldType kField = FieldType::FM64;
+
+  const uint64_t threshold = RefThreshold(kQ, kq);
+
+  // ---- Test vectors: specific boundary cases ----
+  std::vector<uint64_t> mans;
+  std::vector<uint64_t> exps;
+
+  // Edge cases around the normalized range and threshold
+  const uint64_t test_m_vec[] = {
+      0,
+      1,
+      (uint64_t{1} << kQ) - 1,   // 2^Q - 1
+      (uint64_t{1} << kQ),       // 2^Q (min normalized)
+      threshold - 2,
+      threshold - 1,             // just below threshold
+      threshold,                 // at threshold (overflow)
+      threshold + 1,
+      (uint64_t{1} << (kQ + 1)) - 1  // 2^{Q+1} - 1 (max)
+  };
+  const uint64_t test_e_vec[] = {0, 1, 5, 10};
+
+  for (auto m : test_m_vec) {
+    for (auto e : test_e_vec) {
+      mans.push_back(m);
+      exps.push_back(e);
+    }
+  }
+
+  // ---- Random test cases ----
+  std::mt19937_64 rng(42);  // deterministic seed
+  constexpr int kNumRandom = 200;
+  for (int i = 0; i < kNumRandom; ++i) {
+    // Generates values across the full [0, 2^{Q+1}) range
+    uint64_t m = rng() % (uint64_t{1} << (kQ + 1));
+    uint64_t e = rng() % 20;
+    mans.push_back(m);
+    exps.push_back(e);
+  }
+
+  const int64_t numel = static_cast<int64_t>(mans.size());
+  const Shape shape = {numel};
+
+  // ---- Reference outputs (plaintext) ----
+  NdArrayRef ref_m(makeType<RingTy>(kField), shape);
+  NdArrayRef ref_e(makeType<RingTy>(kField), shape);
+  {
+    auto rvm = NdArrayView<uint64_t>(ref_m);
+    auto rve = NdArrayView<uint64_t>(ref_e);
+    for (int64_t i = 0; i < numel; ++i) {
+      RefRoundAndCheck(kQ, kq, mans[static_cast<size_t>(i)],
+                       exps[static_cast<size_t>(i)], rvm[i], rve[i]);
+    }
+  }
+
+  // ---- MPC input ----
+  NdArrayRef msg_m(makeType<RingTy>(kField), shape);
+  NdArrayRef msg_e(makeType<RingTy>(kField), shape);
+  {
+    auto vm = NdArrayView<uint64_t>(msg_m);
+    auto ve = NdArrayView<uint64_t>(msg_e);
+    for (int64_t i = 0; i < numel; ++i) {
+      vm[i] = mans[static_cast<size_t>(i)];
+      ve[i] = exps[static_cast<size_t>(i)];
+    }
+  }
+
+  // Generate input shares ONCE outside simulate
+  auto io = cheetah::makeCheetahIo(kField, kWorldSize);
+  auto m_shares = io->toShares(msg_m, VIS_SECRET, -1);
+  auto e_shares = io->toShares(msg_e, VIS_SECRET, -1);
+
+  std::array<SharedFloat, 2> out_shares;
+  utils::simulate(kWorldSize,
+                  [&](const std::shared_ptr<yacl::link::Context>& lctx) {
+                    auto sctx = spu::mpc::makeCheetahProtocol(MakeConfig(), lctx);
+                    const size_t rank = static_cast<size_t>(lctx->Rank());
+
+                    SharedFloat in;
+                    in.m = ::spu::Value(m_shares[rank], ::spu::DT_INVALID);
+                    in.e = ::spu::Value(e_shares[rank], ::spu::DT_INVALID);
+                    in.z = make_p(sctx.get(), 0, shape, kField);
+                    in.s = make_p(sctx.get(), 0, shape, kField);
+                    in.p = 8;
+                    in.q = kq;
+
+                    out_shares[rank] =
+                        RoundMantissaAndCheckSharedApi(sctx.get(), in, kQ, kq);
+                  });
+
+  // Reconstruct outputs from both parties' shares
+  auto io2 = cheetah::makeCheetahIo(kField, kWorldSize);
+  NdArrayRef got_m =
+      io2->fromShares({out_shares[0].m.data(), out_shares[1].m.data()});
+  NdArrayRef got_e =
+      io2->fromShares({out_shares[0].e.data(), out_shares[1].e.data()});
+
+  auto gmv = NdArrayView<const uint64_t>(got_m);
+  auto gev = NdArrayView<const uint64_t>(got_e);
+  auto rmv = NdArrayView<const uint64_t>(ref_m);
+  auto rev = NdArrayView<const uint64_t>(ref_e);
+
+  // ---- Verify results ----
+  int fails = 0;
+  int ulp_fails = 0;
+  double max_ulp = 0.0;
+
+  for (int64_t i = 0; i < numel; ++i) {
+    const uint64_t in_m = mans[static_cast<size_t>(i)];
+    const int64_t in_e = static_cast<int64_t>(exps[static_cast<size_t>(i)]);
+    const uint64_t gm = gmv[i];
+    const int64_t ge = static_cast<int64_t>(gev[i]);
+    const uint64_t rm = rmv[i];
+    const int64_t re = static_cast<int64_t>(rev[i]);
+
+    const bool match_m = (gm == rm);
+    const bool match_e = (ge == re);
+
+    // ULP computation:
+    //   exact_val = in_m * 2^{in_e - Q}
+    //   approx_val = gm * 2^{ge - q}
+    //   ulp = 2^{ge - q}
+    //   error_ulp = |exact_val - approx_val| / ulp
+    const double exact =
+        static_cast<double>(in_m) * std::ldexp(1.0, static_cast<int>(in_e) - kQ);
+    const double approx =
+        static_cast<double>(gm) * std::ldexp(1.0, static_cast<int>(ge) - kq);
+    const double ulp_val =
+        std::ldexp(1.0, static_cast<int>(ge) - kq);
+    const double error_ulp = std::abs(exact - approx) / ulp_val;
+    max_ulp = std::max(max_ulp, error_ulp);
+
+    if (error_ulp >= 0.5) ++ulp_fails;
+
+    const bool ok = match_m && match_e;
+    if (!ok) ++fails;
+
+    std::cout << (ok ? "OK" : "FAIL") << " [i=" << i << "] "
+              << "in_m=" << in_m << " in_e=" << in_e << "  "
+              << "got_m=" << gm << " got_e=" << ge << "  "
+              << "ref_m=" << rm << " ref_e=" << re << "  "
+              << "ULP=" << error_ulp << std::endl;
+  }
+
+  std::cout << "\n==== Summary ====" << std::endl;
+  std::cout << "Total cases: " << numel << std::endl;
+  std::cout << "Mantissa/exponent mismatches: " << fails << std::endl;
+  std::cout << "ULP >= 0.5 failures: " << ulp_fails << std::endl;
+  std::cout << "Max ULP error: " << max_ulp << std::endl;
+
+  EXPECT_EQ(fails, 0);
+  EXPECT_LT(max_ulp, 0.5);
+}
+
+
+
+void RunRoundCheckProfile(int Q, int q, FieldType field, size_t kNum) {
+  constexpr size_t kW = 2;
+  const Shape shape = {static_cast<int64_t>(kNum)};
+  std::mt19937_64 rng(12345);
+  NdArrayRef msg_m(makeType<RingTy>(field), shape);
+  NdArrayRef msg_e(makeType<RingTy>(field), shape);
+  auto vm = NdArrayView<uint64_t>(msg_m);
+  auto ve = NdArrayView<uint64_t>(msg_e);
+  for (size_t i = 0; i < kNum; ++i) {
+    vm[i] = rng() % (uint64_t{1} << (Q + 1));
+    ve[i] = rng() % 20;
+  }
+  auto io = cheetah::makeCheetahIo(field, kW);
+  auto m_shares = io->toShares(msg_m, VIS_SECRET, -1);
+  auto e_shares = io->toShares(msg_e, VIS_SECRET, -1);
+  utils::simulate(kW, [&](const std::shared_ptr<yacl::link::Context>& lctx) {
+    auto sctx = spu::mpc::makeCheetahProtocol(MakeConfig(), lctx);
+    size_t rank = static_cast<size_t>(lctx->Rank());
+    SharedFloat in;
+    in.m = ::spu::Value(m_shares[rank], ::spu::DT_INVALID);
+    in.e = ::spu::Value(e_shares[rank], ::spu::DT_INVALID);
+    in.z = make_p(sctx.get(), 0, shape, field);
+    in.s = make_p(sctx.get(), 0, shape, field);
+    in.p = 8;
+    in.q = q;
+    if (rank == 0) {
+      auto link_stats = lctx->GetStats();
+      auto sb0 = link_stats->sent_bytes.load();
+      auto rb0 = link_stats->recv_bytes.load();
+      auto sa0 = link_stats->sent_actions.load();
+      auto ra0 = link_stats->recv_actions.load();
+      auto result = RoundMantissaAndCheckSharedApi(sctx.get(), in, Q, q);
+      auto sb1 = link_stats->sent_bytes.load();
+      auto rb1 = link_stats->recv_bytes.load();
+      auto sa1 = link_stats->sent_actions.load();
+      auto ra1 = link_stats->recv_actions.load();
+      size_t total_bytes = (sb1 - sb0) + (rb1 - rb0);
+      size_t total_actions = (sa1 - sa0) + (ra1 - ra0);
+      std::cout << "Round&Check | " << SizeOf(field) * 8 << "-bit ring"
+                << " | n=" << kNum
+                << " | B=" << total_bytes
+                << " | B/elem=" << static_cast<double>(total_bytes) / kNum
+                << " | rounds=" << total_actions
+                << " | r/elem=" << static_cast<double>(total_actions) / kNum
+                << std::endl;
+      (void)result;
+    } else {
+      RoundMantissaAndCheckSharedApi(sctx.get(), in, Q, q);
+    }
+  });
+}
+
+TEST(RoundAndCheckFpApiProfile, Profile) {
+  constexpr int kQ = 15;
+  constexpr int kq = 7;
+  constexpr FieldType kField = FieldType::FM64;
+  std::cout << "\n==== Round&Check Profile ====" << std::endl;
+  std::cout << "Ring: FM64 (" << SizeOf(kField) * 8 << "-bit)"
+            << "  Q=" << kQ << " q=" << kq << " s=" << (kQ - kq)
+            << std::endl;
+  std::cout << "Op | Ring | n | Bytes | B/elem | Rounds | r/elem" << std::endl;
+  std::cout << "------------------------------------------------" << std::endl;
+  for (auto n : {500, 1000, 2000}) {
+    RunRoundCheckProfile(kQ, kq, kField, static_cast<size_t>(n));
+  }
+  std::cout << "================================\n" << std::endl;
+}
+
+}  // namespace spu::mpc::flp


### PR DESCRIPTION
# Pull Request

## What problem does this PR solve?

fix the bug of trunc2_s() function in src/libspu/mpc/api.cc,
Add float-point calculating protocols (fp_add, fp_mul, fp_div) and some building blocks(fp_check, round_and_check_fp_api), with some testing files.

Issue Number: Fixed #

## Possible side effects?
Changed 1 line of the api.cc file

- Performance:Use test files to watch performance(test, ulp_test, perf_test)

- Backward compatibility:full
